### PR TITLE
Enhance GitHub Actions workflow to support manual dispatch and resolve scrape workflow run ID dynamically

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,6 +1,7 @@
 name: Deploy to GitHub Pages
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Spider Shop Spiderlings Scrape"]
     types:
@@ -24,8 +25,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     
-    # Only run if the scrape workflow completed successfully
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Only run if the scrape workflow completed successfully (for workflow_run trigger)
+    # Always run for manual workflow_dispatch
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     
     environment:
       name: github-pages
@@ -37,6 +39,24 @@ jobs:
       # --------------------------------
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # --------------------------------
+      # Resolve scrape workflow run ID
+      # --------------------------------
+      - name: Resolve scrape workflow run ID
+        id: resolve-run
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # Automatic trigger from scrape workflow
+            echo "run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+            echo "Using workflow_run ID: ${{ github.event.workflow_run.id }}"
+          else
+            # Manual dispatch - find latest successful scrape run
+            RUN_ID=$(./scripts/resolve_workflow_run.sh scrape.yml "${{ github.ref_name }}")
+            echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # --------------------------------
       # Python setup
@@ -59,7 +79,7 @@ jobs:
         with:
           name: spidershop-snapshot
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.resolve-run.outputs.run_id }}
         continue-on-error: true
 
       - name: Download history artifact
@@ -67,7 +87,7 @@ jobs:
         with:
           name: spidershop-history
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.resolve-run.outputs.run_id }}
         continue-on-error: true
 
       - name: Download breeder opportunity table
@@ -75,7 +95,7 @@ jobs:
         with:
           name: breeder-opportunity-table
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.resolve-run.outputs.run_id }}
         continue-on-error: true
 
       - name: Download dealer supply risk table
@@ -83,7 +103,7 @@ jobs:
         with:
           name: dealer-supply-risk-table
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.resolve-run.outputs.run_id }}
         continue-on-error: true
 
       - name: Download analysis summary
@@ -91,7 +111,7 @@ jobs:
         with:
           name: analysis-summary
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.resolve-run.outputs.run_id }}
         continue-on-error: true
 
       # --------------------------------

--- a/Makefile
+++ b/Makefile
@@ -80,21 +80,12 @@ help:
 download-artifacts: .check-venv .check-gh
 	@echo "📥 Downloading artifacts from GitHub Actions..."
 	@mkdir -p $(TESTING_DIR)
-	@echo "Finding latest successful workflow run..."
-	@RUN_ID=$$(gh api repos/$(REPO_OWNER)/$(REPO_NAME)/actions/workflows \
-		--paginate \
-		-q '.workflows[] | select(.name == "Spider Shop Spiderlings Scrape") | .id' | head -1); \
-	if [ -z "$$RUN_ID" ]; then \
-		echo "❌ Could not find workflow"; \
-		exit 1; \
-	fi; \
-	LATEST_RUN=$$(gh api repos/$(REPO_OWNER)/$(REPO_NAME)/actions/workflows/$$RUN_ID/runs \
-		-q '.workflow_runs[] | select(.conclusion == "success") | .id' | head -1); \
+	@echo "Resolving workflow run ID..."
+	@LATEST_RUN=$$(./scripts/resolve_workflow_run.sh scrape.yml); \
 	if [ -z "$$LATEST_RUN" ]; then \
-		echo "❌ No successful runs found"; \
+		echo "❌ Failed to resolve workflow run ID"; \
 		exit 1; \
 	fi; \
-	echo "✅ Found latest successful run: $$LATEST_RUN"; \
 	echo "Downloading artifacts..."; \
 	for artifact in spidershop-snapshot spidershop-history breeder-opportunity-table dealer-supply-risk-table analysis-summary; do \
 		echo "  Downloading $$artifact..."; \

--- a/scripts/resolve_workflow_run.sh
+++ b/scripts/resolve_workflow_run.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Resolve the latest successful workflow run ID
+#
+# Usage:
+#   resolve_workflow_run.sh WORKFLOW_FILE [BRANCH]
+#
+# Arguments:
+#   WORKFLOW_FILE - Workflow filename (e.g., "scrape.yml")
+#   BRANCH        - (Optional) Specific branch to search. If omitted, uses current branch with master fallback.
+#
+# Output:
+#   Prints the workflow run ID to stdout
+#
+# Exit codes:
+#   0 - Success
+#   1 - No successful run found
+#   2 - Invalid arguments
+
+set -euo pipefail
+
+# Check arguments
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 WORKFLOW_FILE [BRANCH]" >&2
+    exit 2
+fi
+
+WORKFLOW_FILE="$1"
+DEFAULT_BRANCH="master"
+
+# Determine branch to search
+if [ $# -ge 2 ]; then
+    # Branch explicitly provided
+    CURRENT_BRANCH="$2"
+    echo "Searching for workflow runs on specified branch: $CURRENT_BRANCH" >&2
+else
+    # Detect current branch
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "$DEFAULT_BRANCH")
+    echo "Current branch: $CURRENT_BRANCH" >&2
+    echo "Looking for scrape workflow runs on branch: $CURRENT_BRANCH" >&2
+fi
+
+# Try current branch first
+RUN_ID=$(gh run list \
+    --workflow "$WORKFLOW_FILE" \
+    --branch "$CURRENT_BRANCH" \
+    --status success \
+    --limit 1 \
+    --json databaseId \
+    --jq '.[0].databaseId' 2>/dev/null || echo "")
+
+# Fallback to default branch if no run found and not already on default branch
+if [ -z "$RUN_ID" ] && [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then
+    echo "No successful run found on $CURRENT_BRANCH, falling back to $DEFAULT_BRANCH" >&2
+    RUN_ID=$(gh run list \
+        --workflow "$WORKFLOW_FILE" \
+        --branch "$DEFAULT_BRANCH" \
+        --status success \
+        --limit 1 \
+        --json databaseId \
+        --jq '.[0].databaseId' 2>/dev/null || echo "")
+    
+    if [ -n "$RUN_ID" ]; then
+        echo "✅ Found latest successful run from $DEFAULT_BRANCH: $RUN_ID" >&2
+    fi
+elif [ -n "$RUN_ID" ]; then
+    echo "✅ Found latest successful run from $CURRENT_BRANCH: $RUN_ID" >&2
+fi
+
+# Check if we found a run
+if [ -z "$RUN_ID" ]; then
+    echo "❌ No successful workflow runs found for $WORKFLOW_FILE" >&2
+    exit 1
+fi
+
+# Output the run ID
+echo "$RUN_ID"


### PR DESCRIPTION
This pull request improves the flexibility and reliability of artifact downloads in both the GitHub Actions workflow (`deploy-pages.yml`) and the local development process. The main enhancement is the introduction of a script to automatically resolve the latest successful workflow run ID, supporting both manual and automated deployments, and ensuring artifacts are always fetched from the correct run.

**Workflow and artifact download improvements:**

* Added a new script `scripts/resolve_workflow_run.sh` that determines the latest successful workflow run ID for a given workflow file and branch, with fallback to the default branch if necessary.
* Updated `.github/workflows/deploy-pages.yml` to support manual triggering via `workflow_dispatch` and to use the new script for resolving the correct workflow run ID when downloading artifacts, ensuring compatibility with both manual and automatic runs. [[1]](diffhunk://#diff-0f132b0962009071404990a6789b3466dbd8723d1f7b744f6aca0312396a7900R4) [[2]](diffhunk://#diff-0f132b0962009071404990a6789b3466dbd8723d1f7b744f6aca0312396a7900L27-R30) [[3]](diffhunk://#diff-0f132b0962009071404990a6789b3466dbd8723d1f7b744f6aca0312396a7900R43-R60) [[4]](diffhunk://#diff-0f132b0962009071404990a6789b3466dbd8723d1f7b744f6aca0312396a7900L62-R114)

**Developer tooling update:**

* Modified the `download-artifacts` target in the `Makefile` to use `scripts/resolve_workflow_run.sh` for finding the latest successful workflow run, simplifying the logic and improving reliability.