### PR TITLE
refactor: extract shared demand/price section builders to eliminate duplication

### DIFF
--- a/src/scrape/breeder_matrix.py
+++ b/src/scrape/breeder_matrix.py
@@ -5,7 +5,7 @@ from shared.config import BREEDER_TABLE_FILE, SIGNAL_PRIORITY, TREND_PRIORITY
 from shared.assertions import get_summary_path
 from scrape.wishlist_analysis import compute_wishlist_pressure, get_oos_wishlist_carryover, compute_wishlist_delta
 from shared.sparkline_helpers import extract_historical_values_with_carryforward
-from shared.driver_text_helpers import format_wishlist_pressure, format_delta, format_price_trend
+from shared.driver_text_helpers import build_demand_section, build_price_section
 
 # =====================
 # BREEDER MATRIX (PRICE AWARE) — FIXED TO INCLUDE OUT-OF-STOCK ITEMS
@@ -34,15 +34,9 @@ def _generate_breeder_drivers_text(oos_status, oos_runs, pattern, price_trend, w
     stock_detail = "; ".join(filter(None, [oos_text, status_text]))
     stock_section = f"Stock: {pattern} ({stock_detail})" if stock_detail else f"Stock: {pattern}"
     
-    # Demand section
-    pressure_text = format_wishlist_pressure(wishlist_pressure)
-    delta_text = format_delta(wishlist_delta)
-    demand_section = f"Demand: Wishlist {pressure_text} + {delta_text}"
-    
-    # Price section
-    price_text = format_price_trend(price_trend)
-    price_section = f"Price: {price_text}"
-    
+    demand_section = build_demand_section(wishlist_pressure, wishlist_delta)
+    price_section = build_price_section(price_trend)
+
     return f"{stock_section}; {demand_section}; {price_section}"
 
 

--- a/src/scrape/dealer_matrix.py
+++ b/src/scrape/dealer_matrix.py
@@ -5,7 +5,7 @@ from shared.config import DEALER_TABLE_FILE, SIGNAL_PRIORITY, TREND_PRIORITY
 from shared.assertions import get_summary_path
 from scrape.wishlist_analysis import compute_wishlist_pressure, get_oos_wishlist_carryover, compute_wishlist_delta
 from shared.sparkline_helpers import extract_historical_values_with_carryforward, generate_stock_availability_sparkline
-from shared.driver_text_helpers import format_wishlist_pressure, format_delta, format_price_trend
+from shared.driver_text_helpers import build_demand_section, build_price_section
 
 # =====================
 # DEALER MATRIX (Option B: Price Pressure informational)
@@ -30,15 +30,9 @@ def _generate_dealer_drivers_text(reliability, speed, price_pressure, wishlist_p
     # Stock section
     stock_section = f"Stock: Reliability {reliability} (Restock {speed})"
     
-    # Demand section
-    pressure_text = format_wishlist_pressure(wishlist_pressure)
-    delta_text = format_delta(wishlist_delta)
-    demand_section = f"Demand: Wishlist {pressure_text} + {delta_text}"
-    
-    # Price section
-    price_text = format_price_trend(price_pressure)
-    price_section = f"Price: {price_text}"
-    
+    demand_section = build_demand_section(wishlist_pressure, wishlist_delta)
+    price_section = build_price_section(price_pressure)
+
     return f"{stock_section}; {demand_section}; {price_section}"
 
 

--- a/src/shared/driver_text_helpers.py
+++ b/src/shared/driver_text_helpers.py
@@ -54,3 +54,31 @@ def format_price_trend(price_trend):
         Human-readable string (Rising/Stable/Falling) or original value if not recognized
     """
     return PRICE_TEXT.get(price_trend, price_trend)
+
+
+def build_demand_section(wishlist_pressure: str, wishlist_delta: str) -> str:
+    """Build standardized demand section for driver text.
+
+    Args:
+        wishlist_pressure: Demand level (🔥/⚠️/❌)
+        wishlist_delta: Momentum (↑/→/↓)
+
+    Returns:
+        Formatted demand section (e.g., "Demand: Wishlist High + rising")
+    """
+    pressure_text = format_wishlist_pressure(wishlist_pressure)
+    delta_text = format_delta(wishlist_delta)
+    return f"Demand: Wishlist {pressure_text} + {delta_text}"
+
+
+def build_price_section(price_trend: str) -> str:
+    """Build standardized price section for driver text.
+
+    Args:
+        price_trend: Price direction (↑/→/↓)
+
+    Returns:
+        Formatted price section (e.g., "Price: Rising")
+    """
+    price_text = format_price_trend(price_trend)
+    return f"Price: {price_text}"

--- a/tests/shared_module/test_driver_text_helpers.py
+++ b/tests/shared_module/test_driver_text_helpers.py
@@ -3,7 +3,9 @@ import pytest
 from shared.driver_text_helpers import (
     format_wishlist_pressure,
     format_delta,
-    format_price_trend
+    format_price_trend,
+    build_demand_section,
+    build_price_section,
 )
 
 
@@ -53,3 +55,33 @@ class TestFormatPriceTrend:
     def test_returns_original_for_unknown_values(self):
         assert format_price_trend("Unknown") == "Unknown"
         assert format_price_trend("") == ""
+
+
+class TestBuildDemandSection:
+    """Test demand section builder."""
+
+    @pytest.mark.parametrize("pressure,delta,expected", [
+        ("🔥", "↑", "Demand: Wishlist High + rising"),
+        ("⚠️", "→", "Demand: Wishlist Moderate + stable"),
+        ("❌", "↓", "Demand: Wishlist Low + falling"),
+    ])
+    def test_formats_known_values(self, pressure, delta, expected):
+        assert build_demand_section(pressure, delta) == expected
+
+    def test_falls_back_to_raw_values_for_unknown_inputs(self):
+        assert build_demand_section("X", "Y") == "Demand: Wishlist X + Y"
+
+
+class TestBuildPriceSection:
+    """Test price section builder."""
+
+    @pytest.mark.parametrize("price_trend,expected", [
+        ("↑", "Price: Rising"),
+        ("→", "Price: Stable"),
+        ("↓", "Price: Falling"),
+    ])
+    def test_formats_known_values(self, price_trend, expected):
+        assert build_price_section(price_trend) == expected
+
+    def test_falls_back_to_raw_value_for_unknown_input(self):
+        assert build_price_section("X") == "Price: X"


### PR DESCRIPTION
Closes #69

## Summary

The `_generate_breeder_drivers_text` and `_generate_dealer_drivers_text` functions shared ~20 lines of identical demand and price section logic. This refactor extracts that logic into two reusable helpers in `src/shared/driver_text_helpers.py`.

## Changes

- **`src/shared/driver_text_helpers.py`**: Added `build_demand_section()` and `build_price_section()` helpers
- **`src/scrape/breeder_matrix.py`**: Replaced duplicated demand/price logic with calls to shared helpers
- **`src/scrape/dealer_matrix.py`**: Replaced duplicated demand/price logic with calls to shared helpers
- **`tests/shared_module/test_driver_text_helpers.py`**: Added `TestBuildDemandSection` and `TestBuildPriceSection` test classes

## Test Results

All 564 tests pass. Coverage: `driver_text_helpers.py` 100%, `breeder_matrix.py` 95.91%, `dealer_matrix.py` 99.27%.
