### PR TITLE
refactor: extract get_wishlist_metrics() to eliminate wishlist pressure/delta duplication

### DIFF
--- a/src/scrape/breeder_matrix.py
+++ b/src/scrape/breeder_matrix.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from shared.history_utils import group_by_run, k2
 from shared.config import BREEDER_TABLE_FILE, SIGNAL_PRIORITY, TREND_PRIORITY
-from scrape.wishlist_analysis import compute_wishlist_pressure, get_oos_wishlist_carryover, compute_wishlist_delta
+from scrape.wishlist_analysis import compute_wishlist_pressure, get_wishlist_metrics
 from shared.sparkline_helpers import extract_historical_values_with_carryforward
 from shared.driver_text_helpers import build_drivers_text
 from shared.csv_utils import write_matrix_csv
@@ -161,20 +161,9 @@ def build_breeder_opportunity_table(history_rows):
 
         price_trend = price_trend_for_key(key)
 
-        # Get wishlist pressure with OOS carryover
-        # If species is OUT now, carry forward last known pressure (bounded lookback)
-        # Use lookback_limit=5 to capture wishlist pressure for sustained OOS species (4+ runs)
-        # This allows differentiation between "sustained scarcity" and "sustained scarcity + high demand"
-        if in_current:
-            wishlist_pressure = wishlist_pressure_map.get(key, "❌")
-        else:
-            # Species is OUT - try to carry forward recent pressure
-            carried = get_oos_wishlist_carryover(key, by_run, runs, cur_run)
-            wishlist_pressure = carried if carried else "❌"
-
-        # Compute wishlist delta (momentum signal)
-        # Keep lookback_limit=3 for delta per philosophy: "OUT carryover ≤ 3 runs" for momentum
-        wishlist_delta = compute_wishlist_delta(key, by_run, runs, cur_run)
+        wishlist_pressure, wishlist_delta = get_wishlist_metrics(
+            key, by_run, runs, cur_run, wishlist_pressure_map
+        )
 
         # Recommendation logic (conservative wishlist integration with delta)
         # Base signal driven by Pattern + Price Trend (unchanged)

--- a/src/scrape/dealer_matrix.py
+++ b/src/scrape/dealer_matrix.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from shared.history_utils import group_by_run, k2
 from shared.config import DEALER_TABLE_FILE, SIGNAL_PRIORITY, TREND_PRIORITY
-from scrape.wishlist_analysis import compute_wishlist_pressure, get_oos_wishlist_carryover, compute_wishlist_delta
+from scrape.wishlist_analysis import compute_wishlist_pressure, get_wishlist_metrics
 from shared.sparkline_helpers import extract_historical_values_with_carryforward, generate_stock_availability_sparkline
 from shared.driver_text_helpers import build_drivers_text
 from shared.csv_utils import write_matrix_csv
@@ -46,9 +46,6 @@ def build_dealer_supply_risk_table(history_rows):
     # Compute wishlist pressure for current run
     wishlist_pressure_map = compute_wishlist_pressure(cur_rows)
 
-    # Precompute current run keys for OOS check
-    cur_keys = {k2(r) for r in cur_rows}
-
     prev_prices = {k2(r): r.get("price_gbp", "") for r in by_run[prev_run] if r.get("price_gbp")}
     cur_prices = {k2(r): r.get("price_gbp", "") for r in by_run[cur_run] if r.get("price_gbp")}
 
@@ -92,20 +89,10 @@ def build_dealer_supply_risk_table(history_rows):
             except ValueError:
                 pp = "→"
 
-        # Get wishlist pressure with OOS carryover
-        # If species is OUT now, carry forward last known pressure (bounded lookback)
-        # Use lookback_limit=5 to capture historical demand within reasonable window (same as breeder matrix)
         key = (sci, size)
-        if key in cur_keys:
-            # Species is IN current run
-            wishlist_pressure = wishlist_pressure_map.get(key, "❌")
-        else:
-            # Species is OUT - try to carry forward recent pressure
-            carried = get_oos_wishlist_carryover(key, by_run, runs, cur_run)
-            wishlist_pressure = carried if carried else "❌"
-
-        # Compute wishlist delta (momentum signal)
-        wishlist_delta = compute_wishlist_delta(key, by_run, runs, cur_run)
+        wishlist_pressure, wishlist_delta = get_wishlist_metrics(
+            key, by_run, runs, cur_run, wishlist_pressure_map
+        )
 
         # Dealer risk logic: Supply-first hierarchy with demand as modifier
         # Low reliability species escalate to 🔥 based on supply failure + demand signals

--- a/src/scrape/wishlist_analysis.py
+++ b/src/scrape/wishlist_analysis.py
@@ -236,3 +236,39 @@ def compute_wishlist_delta(key, by_run, runs, cur_run, lookback_limit=WISHLIST_D
         return "↓"
     else:
         return "→"
+
+
+def get_wishlist_metrics(key, by_run, runs, cur_run, wishlist_pressure_map):
+    """Get wishlist pressure and delta for a species with OOS carryover logic.
+
+    Consolidates the repeated pattern from breeder and dealer matrices:
+    - If the species is IN the current run, look up its pressure directly.
+    - If the species is OUT, carry forward the last known pressure (bounded lookback ≤ 5 runs).
+    - Wishlist delta is always computed with its own conservative bounded lookback (≤ 3 runs).
+
+    Args:
+        key: (scientific_name, size_cm) tuple identifying the species/size.
+        by_run: dict mapping run datetime -> list of row dicts.
+        runs: sorted list of run datetimes.
+        cur_run: datetime of the current run.
+        wishlist_pressure_map: pre-computed pressure map for the current run
+            (from ``compute_wishlist_pressure``).
+
+    Returns:
+        Tuple of (wishlist_pressure, wishlist_delta) where each value is
+        one of the standard symbols (🔥/⚠️/❌ and ↑/→/↓ respectively).
+    """
+    cur_keys = {
+        (r.get("scientific_name", ""), r.get("size_cm", ""))
+        for r in by_run[cur_run]
+    }
+
+    if key in cur_keys:
+        wishlist_pressure = wishlist_pressure_map.get(key, "❌")
+    else:
+        carried = get_oos_wishlist_carryover(key, by_run, runs, cur_run)
+        wishlist_pressure = carried if carried else "❌"
+
+    wishlist_delta = compute_wishlist_delta(key, by_run, runs, cur_run)
+
+    return wishlist_pressure, wishlist_delta

--- a/tests/scrape_module/test_wishlist_analysis.py
+++ b/tests/scrape_module/test_wishlist_analysis.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Unit tests for wishlist_analysis.get_wishlist_metrics().
+
+Covers:
+- Species IN the current run (pressure from map, delta from history)
+- Species OUT of the current run with recent carryover available
+- Species OUT with no carryover within the bounded window (→ ❌)
+- Wishlist delta: rising, stable, falling
+"""
+
+import pytest
+from shared.history_utils import group_by_run
+from scrape.wishlist_analysis import compute_wishlist_pressure, get_wishlist_metrics
+from conftest import make_row
+
+
+def _setup(history_rows):
+    """Return (key_fn, by_run, runs, cur_run, wishlist_pressure_map) from raw rows."""
+    by_run = group_by_run(history_rows)
+    runs = sorted(by_run)
+    cur_run = runs[-1]
+    wishlist_pressure_map = compute_wishlist_pressure(by_run[cur_run])
+    return by_run, runs, cur_run, wishlist_pressure_map
+
+
+class TestGetWishlistMetrics:
+    """Tests for the get_wishlist_metrics() shared utility."""
+
+    # -----------------------------------------------------------------
+    # IN-stock species
+    # -----------------------------------------------------------------
+
+    def test_in_stock_returns_pressure_from_map(self):
+        """Species present in current run — pressure comes directly from wishlist_pressure_map."""
+        # Two runs; species present in both with very different wishlist counts so
+        # ranking produces a deterministic 🔥 result for the high-count species.
+        history = [
+            make_row("2025-01-01", "Aphonopelma seemanni", "1.0", "25.00", "1"),
+            make_row("2025-01-01", "Grammostola pulchra", "2.0", "40.00", "1"),
+            make_row("2025-01-01", "Lasiodora parahybana", "1.5", "20.00", "50"),
+            make_row("2025-01-08", "Aphonopelma seemanni", "1.0", "25.00", "2"),
+            make_row("2025-01-08", "Grammostola pulchra", "2.0", "40.00", "2"),
+            make_row("2025-01-08", "Lasiodora parahybana", "1.5", "20.00", "50"),
+        ]
+
+        by_run, runs, cur_run, wishlist_pressure_map = _setup(history)
+        key = ("Lasiodora parahybana", "1.5")
+
+        wishlist_pressure, _ = get_wishlist_metrics(key, by_run, runs, cur_run, wishlist_pressure_map)
+
+        assert wishlist_pressure == "🔥"
+
+    def test_in_stock_zero_wishlist_returns_no_pressure(self):
+        """Species in current run with wishlist 0 → ❌ pressure."""
+        history = [
+            make_row("2025-01-01", "Aphonopelma seemanni", "1.0", "25.00", "0"),
+            make_row("2025-01-08", "Aphonopelma seemanni", "1.0", "25.00", "0"),
+        ]
+
+        by_run, runs, cur_run, wishlist_pressure_map = _setup(history)
+        key = ("Aphonopelma seemanni", "1.0")
+
+        wishlist_pressure, _ = get_wishlist_metrics(key, by_run, runs, cur_run, wishlist_pressure_map)
+
+        assert wishlist_pressure == "❌"
+
+    def test_in_stock_rising_wishlist_returns_up_delta(self):
+        """Wishlist count rising by ≥5 across runs → ↑ delta."""
+        history = [
+            make_row("2025-01-01", "Aphonopelma seemanni", "1.0", "25.00", "10"),
+            make_row("2025-01-08", "Aphonopelma seemanni", "1.0", "25.00", "20"),
+        ]
+
+        by_run, runs, cur_run, wishlist_pressure_map = _setup(history)
+        key = ("Aphonopelma seemanni", "1.0")
+
+        _, wishlist_delta = get_wishlist_metrics(key, by_run, runs, cur_run, wishlist_pressure_map)
+
+        assert wishlist_delta == "↑"
+
+    def test_in_stock_stable_wishlist_returns_neutral_delta(self):
+        """Wishlist count change within ±4 → → delta."""
+        history = [
+            make_row("2025-01-01", "Aphonopelma seemanni", "1.0", "25.00", "10"),
+            make_row("2025-01-08", "Aphonopelma seemanni", "1.0", "25.00", "12"),
+        ]
+
+        by_run, runs, cur_run, wishlist_pressure_map = _setup(history)
+        key = ("Aphonopelma seemanni", "1.0")
+
+        _, wishlist_delta = get_wishlist_metrics(key, by_run, runs, cur_run, wishlist_pressure_map)
+
+        assert wishlist_delta == "→"
+
+    def test_in_stock_falling_wishlist_returns_down_delta(self):
+        """Wishlist count falling by ≥5 → ↓ delta."""
+        history = [
+            make_row("2025-01-01", "Aphonopelma seemanni", "1.0", "25.00", "20"),
+            make_row("2025-01-08", "Aphonopelma seemanni", "1.0", "25.00", "10"),
+        ]
+
+        by_run, runs, cur_run, wishlist_pressure_map = _setup(history)
+        key = ("Aphonopelma seemanni", "1.0")
+
+        _, wishlist_delta = get_wishlist_metrics(key, by_run, runs, cur_run, wishlist_pressure_map)
+
+        assert wishlist_delta == "↓"
+
+    # -----------------------------------------------------------------
+    # OUT-of-stock species — carryover
+    # -----------------------------------------------------------------
+
+    def test_out_of_stock_carries_forward_recent_pressure(self):
+        """Species OUT in current run but IN recent run → pressure carried forward."""
+        # Run 1: species present with high wishlist; Run 2: species OUT.
+        # Carryover should return the pressure from run 1.
+        history = [
+            # Filler species so run 1 has enough variety for a meaningful distribution
+            make_row("2025-01-01", "Aphonopelma seemanni", "1.0", "25.00", "1"),
+            make_row("2025-01-01", "Grammostola pulchra", "2.0", "40.00", "2"),
+            make_row("2025-01-01", "Lasiodora parahybana", "1.5", "20.00", "50"),
+            # Run 2: Lasiodora goes OUT; other species remain
+            make_row("2025-01-08", "Aphonopelma seemanni", "1.0", "25.00", "1"),
+            make_row("2025-01-08", "Grammostola pulchra", "2.0", "40.00", "2"),
+        ]
+
+        by_run, runs, cur_run, wishlist_pressure_map = _setup(history)
+        key = ("Lasiodora parahybana", "1.5")
+
+        wishlist_pressure, _ = get_wishlist_metrics(key, by_run, runs, cur_run, wishlist_pressure_map)
+
+        assert wishlist_pressure == "🔥"
+
+    def test_out_of_stock_no_recent_history_returns_no_pressure(self):
+        """Species never present in history → ❌ pressure (no carryover possible)."""
+        history = [
+            make_row("2025-01-01", "Aphonopelma seemanni", "1.0", "25.00", "5"),
+            make_row("2025-01-08", "Aphonopelma seemanni", "1.0", "25.00", "5"),
+        ]
+
+        by_run, runs, cur_run, wishlist_pressure_map = _setup(history)
+        key = ("Unknown spider", "1.0")  # not in any run
+
+        wishlist_pressure, _ = get_wishlist_metrics(key, by_run, runs, cur_run, wishlist_pressure_map)
+
+        assert wishlist_pressure == "❌"
+
+    def test_out_of_stock_beyond_carryover_limit_returns_no_pressure(self):
+        """Species last seen more than 5 runs ago → carryover expires → ❌ pressure."""
+        # 7 runs; species present only in run 1, absent for 6 consecutive runs.
+        history = [make_row("2025-01-01", "Lasiodora parahybana", "1.5", "20.00", "50")]
+        filler = "Aphonopelma seemanni"
+        for week in range(1, 7):
+            dt = f"2025-01-{(1 + week * 7):02d}"
+            history.append(make_row(dt, filler, "1.0", "25.00", "5"))
+
+        by_run, runs, cur_run, wishlist_pressure_map = _setup(history)
+        key = ("Lasiodora parahybana", "1.5")
+
+        wishlist_pressure, _ = get_wishlist_metrics(key, by_run, runs, cur_run, wishlist_pressure_map)
+
+        assert wishlist_pressure == "❌"
+
+    def test_out_of_stock_returns_neutral_delta_when_no_prior_comparison(self):
+        """Species OUT for the first time (no previous comparable run) → → delta."""
+        history = [
+            make_row("2025-01-01", "Aphonopelma seemanni", "1.0", "25.00", "10"),
+            # Run 2: species disappears — only one historical observation available
+            make_row("2025-01-08", "Grammostola pulchra", "2.0", "40.00", "5"),
+        ]
+
+        by_run, runs, cur_run, wishlist_pressure_map = _setup(history)
+        key = ("Aphonopelma seemanni", "1.0")
+
+        _, wishlist_delta = get_wishlist_metrics(key, by_run, runs, cur_run, wishlist_pressure_map)
+
+        assert wishlist_delta == "→"


### PR DESCRIPTION
## Summary

Extracts the repeated wishlist pressure + delta retrieval block from breeder_matrix.py and dealer_matrix.py into a single get_wishlist_metrics() utility in wishlist_analysis.py.

## Changes

- src/scrape/wishlist_analysis.py: new get_wishlist_metrics() function
- src/scrape/breeder_matrix.py: replaced 10-line duplicate block with single call; updated import
- src/scrape/dealer_matrix.py: same replacement; removed now-unused cur_keys; updated import
- tests/scrape_module/test_wishlist_analysis.py: 9 new tests covering IN-stock, OOS carryover, expired carryover, and all three delta directions

## Test results

- 541 unit tests pass, 97 E2E skipped
- scrape/wishlist_analysis.py coverage: 86% (threshold 80%)

Closes #80