### PR TITLE
Refactor duplicated stable page entry initialization

### DIFF
--- a/client/src/breeder-page/config.ts
+++ b/client/src/breeder-page/config.ts
@@ -1,0 +1,30 @@
+import { wireOpenDetailsLinks } from '../shared/dom-utils.js';
+import type { SortableTablePageConfig } from '../shared/page-init.js';
+
+export const BREEDER_PAGE_CONFIG: SortableTablePageConfig = {
+  tableId: 'breeder-table',
+  columns: [
+    { key: 'Species', type: 'species-link', linkViewParam: 'breeder' },
+    { key: 'Size (cm)' },
+    { key: 'OOS' },
+    { key: 'OOS Runs' },
+    { key: 'Stock Pattern' },
+    { key: 'Price', label: 'Price Trend' },
+    { key: 'Price History', type: 'sparkline' },
+    { key: 'Wishlist' },
+    { key: 'Wishlist History', type: 'sparkline' },
+    { key: 'Signal' },
+    { key: 'Recommendation' },
+    { key: 'Drivers', hidden: true },
+  ],
+  filterConfig: {
+    signalFilter: { column: 'Signal', top10: true },
+    stockPatternFilter: { column: 'Stock Pattern' },
+    priceColumn: 'Price',
+    wishlistColumn: 'Wishlist',
+    showSearch: true,
+    statsLabel: 'species',
+    driversKey: 'Drivers',
+  },
+  postMount: wireOpenDetailsLinks,
+};

--- a/client/src/breeder-page/index.ts
+++ b/client/src/breeder-page/index.ts
@@ -1,46 +1,4 @@
-/**
- * Breeder Opportunities Page
- *
- * Mounts the SortableTable Svelte component into the breeder-table root element,
- * reading table data from the window global injected by the Python template.
- */
+import { BREEDER_PAGE_CONFIG } from './config.js';
+import { registerSortableTablePage } from '../shared/page-init.js';
 
-import type { ColumnConfig, FilterConfig } from '../shared/components/SortableTable.svelte';
-import { wireOpenDetailsLinks } from '../shared/dom-utils.js';
-import { initSortableTablePage, registerPageInit } from '../shared/page-init.js';
-
-const TABLE_ID = 'breeder-table';
-
-const COLUMNS: ColumnConfig[] = [
-  { key: 'Species', label: 'Species', type: 'species-link', linkViewParam: 'breeder' },
-  { key: 'Size (cm)', label: 'Size (cm)' },
-  { key: 'OOS', label: 'OOS' },
-  { key: 'OOS Runs', label: 'OOS Runs' },
-  { key: 'Stock Pattern', label: 'Stock Pattern' },
-  { key: 'Price', label: 'Price Trend' },
-  { key: 'Price History', label: 'Price History', type: 'sparkline' },
-  { key: 'Wishlist', label: 'Wishlist' },
-  { key: 'Wishlist History', label: 'Wishlist History', type: 'sparkline' },
-  { key: 'Signal', label: 'Signal' },
-  { key: 'Recommendation', label: 'Recommendation' },
-  { key: 'Drivers', label: 'Drivers', hidden: true },
-];
-
-const FILTER_CONFIG: FilterConfig = {
-  signalFilter: { column: 'Signal', top10: true },
-  stockPatternFilter: { column: 'Stock Pattern' },
-  priceColumn: 'Price',
-  wishlistColumn: 'Wishlist',
-  showSearch: true,
-  statsLabel: 'species',
-  driversKey: 'Drivers',
-};
-
-registerPageInit(() => {
-  initSortableTablePage({
-    tableId: TABLE_ID,
-    columns: COLUMNS,
-    filterConfig: FILTER_CONFIG,
-    postMount: wireOpenDetailsLinks,
-  });
-});
+registerSortableTablePage(BREEDER_PAGE_CONFIG);

--- a/client/src/dealer-page/config.ts
+++ b/client/src/dealer-page/config.ts
@@ -1,0 +1,30 @@
+import { wireOpenDetailsLinks } from '../shared/dom-utils.js';
+import type { SortableTablePageConfig } from '../shared/page-init.js';
+
+export const DEALER_PAGE_CONFIG: SortableTablePageConfig = {
+  tableId: 'dealer-table',
+  columns: [
+    { key: 'Species', type: 'species-link', linkViewParam: 'dealer' },
+    { key: 'Size (cm)' },
+    { key: 'Stock Reliability' },
+    { key: 'Avg OOS Duration' },
+    { key: 'Restock Speed' },
+    { key: 'Price', label: 'Price Trend' },
+    { key: 'Price History', type: 'sparkline' },
+    { key: 'Wishlist' },
+    { key: 'Wishlist History', type: 'sparkline' },
+    { key: 'Stock Availability', type: 'sparkline' },
+    { key: 'Dealer Risk' },
+    { key: 'Dealer Recommendation' },
+    { key: 'Drivers', hidden: true },
+  ],
+  filterConfig: {
+    signalFilter: { column: 'Dealer Risk', top10: true },
+    priceColumn: 'Price',
+    wishlistColumn: 'Wishlist',
+    showSearch: true,
+    statsLabel: 'species',
+    driversKey: 'Drivers',
+  },
+  postMount: wireOpenDetailsLinks,
+};

--- a/client/src/dealer-page/index.ts
+++ b/client/src/dealer-page/index.ts
@@ -1,46 +1,4 @@
-/**
- * Dealer Supply Risk Page
- *
- * Mounts the SortableTable Svelte component into the dealer-table root element,
- * reading table data from the window global injected by the Python template.
- */
+import { DEALER_PAGE_CONFIG } from './config.js';
+import { registerSortableTablePage } from '../shared/page-init.js';
 
-import type { ColumnConfig, FilterConfig } from '../shared/components/SortableTable.svelte';
-import { wireOpenDetailsLinks } from '../shared/dom-utils.js';
-import { initSortableTablePage, registerPageInit } from '../shared/page-init.js';
-
-const TABLE_ID = 'dealer-table';
-
-const COLUMNS: ColumnConfig[] = [
-  { key: 'Species', label: 'Species', type: 'species-link', linkViewParam: 'dealer' },
-  { key: 'Size (cm)', label: 'Size (cm)' },
-  { key: 'Stock Reliability', label: 'Stock Reliability' },
-  { key: 'Avg OOS Duration', label: 'Avg OOS Duration' },
-  { key: 'Restock Speed', label: 'Restock Speed' },
-  { key: 'Price', label: 'Price Trend' },
-  { key: 'Price History', label: 'Price History', type: 'sparkline' },
-  { key: 'Wishlist', label: 'Wishlist' },
-  { key: 'Wishlist History', label: 'Wishlist History', type: 'sparkline' },
-  { key: 'Stock Availability', label: 'Stock Availability', type: 'sparkline' },
-  { key: 'Dealer Risk', label: 'Dealer Risk' },
-  { key: 'Dealer Recommendation', label: 'Dealer Recommendation' },
-  { key: 'Drivers', label: 'Drivers', hidden: true },
-];
-
-const FILTER_CONFIG: FilterConfig = {
-  signalFilter: { column: 'Dealer Risk', top10: true },
-  priceColumn: 'Price',
-  wishlistColumn: 'Wishlist',
-  showSearch: true,
-  statsLabel: 'species',
-  driversKey: 'Drivers',
-};
-
-registerPageInit(() => {
-  initSortableTablePage({
-    tableId: TABLE_ID,
-    columns: COLUMNS,
-    filterConfig: FILTER_CONFIG,
-    postMount: wireOpenDetailsLinks,
-  });
-});
+registerSortableTablePage(DEALER_PAGE_CONFIG);

--- a/client/src/history-page/HistoryTable.svelte
+++ b/client/src/history-page/HistoryTable.svelte
@@ -247,7 +247,7 @@
             data-sort-direction={sort.key === col.key ? sort.dir : 'none'}
             onclick={() => sort.toggle(col.key)}
           >
-            {col.label}
+            {col.label ?? col.key}
             <span class="sort-indicator">{sort.key === col.key ? (sort.dir === 'asc' ? '↑' : '↓') : '⇅'}</span>
           </th>
         {/each}

--- a/client/src/history-page/HistoryTable.test.ts
+++ b/client/src/history-page/HistoryTable.test.ts
@@ -83,6 +83,23 @@ test('table element has correct id', () => {
   expect(container.querySelector('#history-table')).not.toBeNull();
 });
 
+test('uses key as the header label when label is omitted', () => {
+  const { container } = renderTable({
+    columns: [
+      { key: 'Scrape Date', csvHeader: 'scrape_datetime', rawValueKey: '_raw_scrape_datetime' },
+      { key: 'Scientific Name' },
+      { key: 'Price (GBP)' },
+      { key: 'Wishlist Count' },
+    ],
+  });
+
+  const headers = Array.from(container.querySelectorAll('thead th')).map((th) =>
+    (th.textContent ?? '').replace(/[\u21c5\u2191\u2193]/g, '').trim(),
+  );
+
+  expect(headers).toEqual(['Scrape Date', 'Scientific Name', 'Price (GBP)', 'Wishlist Count']);
+});
+
 test('summary info strip is rendered when dateColumn is set', () => {
   const { container } = renderTable();
   expect(container.querySelector('#summary-info-history-table')).not.toBeNull();

--- a/client/src/shared/components/SortableTable.svelte
+++ b/client/src/shared/components/SortableTable.svelte
@@ -17,7 +17,7 @@
 
   export interface ColumnConfig {
     key: string;
-    label: string;
+    label?: string;
     type?: 'sparkline' | 'species-link' | 'page-url';
     linkViewParam?: string;
     /** Row key to use as the visible link text for page-url columns (defaults to the raw URL). */
@@ -375,7 +375,7 @@
               data-sort-direction={sort.key === col.key ? sort.dir : 'none'}
               onclick={() => sort.toggle(col.key)}
             >
-              {col.label}
+              {col.label ?? col.key}
               <span class="sort-indicator">{sort.key === col.key ? (sort.dir === 'asc' ? '↑' : '↓') : '⇅'}</span>
             </th>
           {/if}

--- a/client/src/shared/components/SortableTable.test.ts
+++ b/client/src/shared/components/SortableTable.test.ts
@@ -58,6 +58,20 @@ test('renders correct column headers', () => {
   expect(headers).toEqual(['Species', 'Signal', 'Stock Pattern', 'Price']);
 });
 
+test('uses key as the header label when label is omitted', () => {
+  const { container } = render(SortableTable, {
+    tableId: 'test-table',
+    rows: ROWS,
+    columns: [{ key: 'Species' }, { key: 'Signal' }],
+  });
+
+  const headers = Array.from(container.querySelectorAll('thead th')).map((th) =>
+    (th.textContent ?? '').replace(/[\u21c5\u2191\u2193]/g, '').trim(),
+  );
+
+  expect(headers).toEqual(['Species', 'Signal']);
+});
+
 test('visible count reflects total rows initially', () => {
   const { container } = renderTable();
   expect(container.querySelector('#visible-count-test-table')?.textContent).toBe('3');

--- a/client/src/shared/page-init.test.ts
+++ b/client/src/shared/page-init.test.ts
@@ -18,7 +18,15 @@ vi.mock('./components/SortableTable.svelte', () => ({
 }));
 
 import SortableTable from './components/SortableTable.svelte';
-import { completeTableMount, initSortableTablePage, registerPageInit } from './page-init.js';
+import { BREEDER_PAGE_CONFIG } from '../breeder-page/config.js';
+import { DEALER_PAGE_CONFIG } from '../dealer-page/config.js';
+import { SNAPSHOT_PAGE_CONFIG } from '../snapshot-page/config.js';
+import {
+  completeTableMount,
+  initSortableTablePage,
+  registerPageInit,
+  registerSortableTablePage,
+} from './page-init.js';
 
 describe('initSortableTablePage', () => {
   let performanceNowSpy: ReturnType<typeof vi.spyOn>;
@@ -213,5 +221,115 @@ describe('registerPageInit', () => {
 
     expect(init).not.toHaveBeenCalled();
     expect(addEventListenerSpy).toHaveBeenCalledWith('DOMContentLoaded', init);
+  });
+});
+
+describe('registerSortableTablePage', () => {
+  let performanceNowSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    mountMock.mockReset();
+    assertPayloadMock.mockReset();
+    vi.useFakeTimers();
+    performanceNowSpy = vi.spyOn(performance, 'now').mockReturnValue(40);
+    delete (window as Window & Record<string, unknown>)['snapshot-tableData'];
+    delete (document as Document & { readyState?: DocumentReadyState }).readyState;
+  });
+
+  afterEach(() => {
+    performanceNowSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('registers and mounts a stable sortable table page from shared config', () => {
+    const rows = [{ 'Common Name': 'Costa Rican Zebra' }];
+    document.body.innerHTML = `
+      <div data-table-shell="snapshot-table" data-table-ready="false">
+        <div data-table-skeleton-for="snapshot-table"></div>
+        <div id="snapshot-table-root"></div>
+      </div>
+    `;
+    (window as Window & Record<string, unknown>)['snapshot-tableData'] = rows;
+
+    registerSortableTablePage({
+      tableId: 'snapshot-table',
+      columns: [{ key: 'Common Name', label: 'Common Name' }],
+      filterConfig: { showSearch: true, statsLabel: 'species' },
+      primaryToggle: true,
+    });
+
+    expect(assertPayloadMock).toHaveBeenCalledWith('snapshot-table', rows);
+    expect(mountMock).toHaveBeenCalledWith(SortableTable, {
+      target: document.getElementById('snapshot-table-root'),
+      props: {
+        tableId: 'snapshot-table',
+        rows,
+        columns: [{ key: 'Common Name', label: 'Common Name' }],
+        filterConfig: { showSearch: true, statsLabel: 'species' },
+        primaryToggle: true,
+      },
+    });
+  });
+});
+
+describe('stable page configs', () => {
+  it('preserves the breeder page table and filter configuration', () => {
+    expect(BREEDER_PAGE_CONFIG.tableId).toBe('breeder-table');
+    expect(BREEDER_PAGE_CONFIG.filterConfig).toEqual({
+      signalFilter: { column: 'Signal', top10: true },
+      stockPatternFilter: { column: 'Stock Pattern' },
+      priceColumn: 'Price',
+      wishlistColumn: 'Wishlist',
+      showSearch: true,
+      statsLabel: 'species',
+      driversKey: 'Drivers',
+    });
+    expect(BREEDER_PAGE_CONFIG.postMount).toBeTypeOf('function');
+    expect(BREEDER_PAGE_CONFIG.columns).toEqual(
+      expect.arrayContaining([
+        { key: 'Species', type: 'species-link', linkViewParam: 'breeder' },
+        { key: 'Drivers', hidden: true },
+      ]),
+    );
+  });
+
+  it('preserves the dealer page table and filter configuration', () => {
+    expect(DEALER_PAGE_CONFIG.tableId).toBe('dealer-table');
+    expect(DEALER_PAGE_CONFIG.filterConfig).toEqual({
+      signalFilter: { column: 'Dealer Risk', top10: true },
+      priceColumn: 'Price',
+      wishlistColumn: 'Wishlist',
+      showSearch: true,
+      statsLabel: 'species',
+      driversKey: 'Drivers',
+    });
+    expect(DEALER_PAGE_CONFIG.postMount).toBeTypeOf('function');
+    expect(DEALER_PAGE_CONFIG.columns).toEqual(
+      expect.arrayContaining([
+        { key: 'Species', type: 'species-link', linkViewParam: 'dealer' },
+        { key: 'Stock Availability', type: 'sparkline' },
+      ]),
+    );
+  });
+
+  it('preserves the snapshot page table and filter configuration', () => {
+    expect(SNAPSHOT_PAGE_CONFIG).toEqual({
+      tableId: 'snapshot-table',
+      columns: [
+        { key: 'Common Name' },
+        { key: 'Scientific Name' },
+        { key: 'Size (cm)' },
+        { key: 'Price (GBP)' },
+        { key: 'Wishlist Count' },
+      ],
+      filterConfig: {
+        priceColumn: 'Price (GBP)',
+        wishlistColumn: 'Wishlist Count',
+        showSearch: true,
+        statsLabel: 'species',
+      },
+      primaryToggle: true,
+    });
   });
 });

--- a/client/src/shared/page-init.ts
+++ b/client/src/shared/page-init.ts
@@ -63,6 +63,12 @@ export function initSortableTablePage(config: SortableTablePageConfig): void {
   postMount?.();
 }
 
+export function registerSortableTablePage(config: SortableTablePageConfig): void {
+  registerPageInit(() => {
+    initSortableTablePage(config);
+  });
+}
+
 export function registerPageInit(init: () => void): void {
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init);

--- a/client/src/snapshot-page/config.ts
+++ b/client/src/snapshot-page/config.ts
@@ -1,0 +1,19 @@
+import type { SortableTablePageConfig } from '../shared/page-init.js';
+
+export const SNAPSHOT_PAGE_CONFIG: SortableTablePageConfig = {
+  tableId: 'snapshot-table',
+  columns: [
+    { key: 'Common Name' },
+    { key: 'Scientific Name' },
+    { key: 'Size (cm)' },
+    { key: 'Price (GBP)' },
+    { key: 'Wishlist Count' },
+  ],
+  filterConfig: {
+    priceColumn: 'Price (GBP)',
+    wishlistColumn: 'Wishlist Count',
+    showSearch: true,
+    statsLabel: 'species',
+  },
+  primaryToggle: true,
+};

--- a/client/src/snapshot-page/index.ts
+++ b/client/src/snapshot-page/index.ts
@@ -1,35 +1,4 @@
-/**
- * Latest Snapshot Page
- *
- * Mounts the SortableTable Svelte component into the snapshot-table root element,
- * reading table data from the window global injected by the Python template.
- */
+import { SNAPSHOT_PAGE_CONFIG } from './config.js';
+import { registerSortableTablePage } from '../shared/page-init.js';
 
-import type { ColumnConfig, FilterConfig } from '../shared/components/SortableTable.svelte';
-import { initSortableTablePage, registerPageInit } from '../shared/page-init.js';
-
-const TABLE_ID = 'snapshot-table';
-
-const COLUMNS: ColumnConfig[] = [
-  { key: 'Common Name', label: 'Common Name' },
-  { key: 'Scientific Name', label: 'Scientific Name' },
-  { key: 'Size (cm)', label: 'Size (cm)' },
-  { key: 'Price (GBP)', label: 'Price (GBP)' },
-  { key: 'Wishlist Count', label: 'Wishlist Count' },
-];
-
-const FILTER_CONFIG: FilterConfig = {
-  priceColumn: 'Price (GBP)',
-  wishlistColumn: 'Wishlist Count',
-  showSearch: true,
-  statsLabel: 'species',
-};
-
-registerPageInit(() => {
-  initSortableTablePage({
-    tableId: TABLE_ID,
-    columns: COLUMNS,
-    filterConfig: FILTER_CONFIG,
-    primaryToggle: true,
-  });
-});
+registerSortableTablePage(SNAPSHOT_PAGE_CONFIG);


### PR DESCRIPTION
## Summary
- add a shared `registerSortableTablePage()` helper in the existing page-init module
- extract breeder, dealer, and snapshot table configs into per-slice `config.ts` files
- keep `history-page` unchanged because the migration plan marks that slice as transitional and not a target for shared abstraction
- add client tests for the new helper and the extracted configs

## Testing
- make test-client-file FILE=src/shared/page-init.test.ts
- make test-client-fast
- make test-client
- make test-e2e

Closes #119
Closes #120