### PR TITLE
Refactor shared matrix builder setup

### DIFF
--- a/src/scrape/breeder_matrix.py
+++ b/src/scrape/breeder_matrix.py
@@ -5,12 +5,11 @@ from shared.driver_text_helpers import build_drivers_text
 from shared.price_text_helpers import format_price_cell
 from shared.summary_utils import MatrixOutputConfig, write_matrix_outputs
 from scrape.matrix_workflow import (
+    MatrixContext,
     collect_lookback_values_for_key,
     generate_price_wishlist_sparklines,
     get_wishlist_display_metrics,
     iter_lookback_rows_for_key,
-    prepare_matrix_analysis,
-    prepare_matrix_runs,
     sort_matrix_table,
 )
 
@@ -51,16 +50,18 @@ def _generate_breeder_drivers_text(oos_status: str, oos_runs: int, pattern: str,
 
 
 def build_breeder_opportunity_table(history_rows):
-    prepared = prepare_matrix_analysis(history_rows)
-    if prepared is None:
+    context = MatrixContext.from_history(history_rows)
+    if context is None:
         return []
 
-    by_run, runs, cur_run, prev_run, cur_rows, run_index, wishlist_pressure_map = prepared
-    prev_rows = by_run[prev_run]
-
-    # Index rows by (species,size) for quick lookup
-    cur_map = {k2(r): r for r in cur_rows}
-    prev_map = {k2(r): r for r in prev_rows}
+    by_run = context.by_run
+    runs = context.runs
+    cur_run = context.current_run
+    prev_run = context.previous_run
+    run_index = context.run_index
+    wishlist_pressure_map = context.wishlist_pressure_map
+    cur_map = context.current_map
+    prev_map = context.previous_map
 
     # Union of keys across ALL history so OUT items can appear in the breeder table
     all_keys = set()

--- a/src/scrape/dealer_matrix.py
+++ b/src/scrape/dealer_matrix.py
@@ -6,11 +6,10 @@ from shared.driver_text_helpers import build_drivers_text
 from shared.price_text_helpers import format_price_cell
 from shared.summary_utils import MatrixOutputConfig, write_matrix_outputs
 from scrape.matrix_workflow import (
+    MatrixContext,
     collect_lookback_values_for_key,
     generate_price_wishlist_sparklines,
     get_wishlist_display_metrics,
-    prepare_matrix_analysis,
-    prepare_matrix_runs,
     sort_matrix_table,
 )
 
@@ -39,11 +38,16 @@ def _generate_dealer_drivers_text(reliability: str, speed: str, price_pressure: 
 
 
 def build_dealer_supply_risk_table(history_rows):
-    prepared = prepare_matrix_analysis(history_rows)
-    if prepared is None:
+    context = MatrixContext.from_history(history_rows)
+    if context is None:
         return []
 
-    by_run, runs, cur_run, prev_run, cur_rows, run_index, wishlist_pressure_map = prepared
+    by_run = context.by_run
+    runs = context.runs
+    cur_run = context.current_run
+    prev_run = context.previous_run
+    run_index = context.run_index
+    wishlist_pressure_map = context.wishlist_pressure_map
     total_runs = len(runs)
 
     prev_prices = {k2(r): r.get("price_gbp", "") for r in by_run[prev_run] if r.get("price_gbp")}

--- a/src/scrape/matrix_workflow.py
+++ b/src/scrape/matrix_workflow.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Shared workflow helpers for scrape matrix builders."""
 
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from scrape.wishlist_analysis import (
@@ -11,6 +12,44 @@ from scrape.wishlist_analysis import (
 from shared.config import OOS_CARRYOVER_LOOKBACK, SIGNAL_PRIORITY
 from shared.history_utils import group_by_run, k2
 from shared.sparkline_helpers import extract_historical_values_with_carryforward
+
+
+@dataclass(frozen=True)
+class MatrixContext:
+    """Shared context prepared once for matrix table builders."""
+
+    by_run: Dict[str, List[Dict[str, Any]]]
+    runs: List[str]
+    current_run: str
+    previous_run: str
+    current_rows: List[Dict[str, Any]]
+    previous_rows: List[Dict[str, Any]]
+    run_index: Dict[str, int]
+    wishlist_pressure_map: Dict[Tuple[str, str], str]
+    current_map: Dict[Tuple[str, str], Dict[str, Any]]
+    previous_map: Dict[Tuple[str, str], Dict[str, Any]]
+
+    @classmethod
+    def from_history(cls, history_rows: List[Dict[str, Any]]) -> Optional["MatrixContext"]:
+        """Build shared matrix context from historical rows."""
+        prepared = prepare_matrix_runs(history_rows)
+        if prepared is None:
+            return None
+
+        by_run, runs, current_run, previous_run, current_rows = prepared
+        previous_rows = by_run[previous_run]
+        return cls(
+            by_run=by_run,
+            runs=runs,
+            current_run=current_run,
+            previous_run=previous_run,
+            current_rows=current_rows,
+            previous_rows=previous_rows,
+            run_index={run_timestamp: idx for idx, run_timestamp in enumerate(runs)},
+            wishlist_pressure_map=compute_wishlist_pressure(current_rows),
+            current_map={k2(row): row for row in current_rows},
+            previous_map={k2(row): row for row in previous_rows},
+        )
 
 
 def prepare_matrix_runs(
@@ -45,21 +84,18 @@ def prepare_matrix_analysis(
     ]
 ]:
     """Prepare shared matrix builder context including run indices and wishlist pressure."""
-    prepared = prepare_matrix_runs(history_rows)
-    if prepared is None:
+    context = MatrixContext.from_history(history_rows)
+    if context is None:
         return None
 
-    by_run, runs, current_run, previous_run, current_rows = prepared
-    run_index = {run_timestamp: idx for idx, run_timestamp in enumerate(runs)}
-    wishlist_pressure_map = compute_wishlist_pressure(current_rows)
     return (
-        by_run,
-        runs,
-        current_run,
-        previous_run,
-        current_rows,
-        run_index,
-        wishlist_pressure_map,
+        context.by_run,
+        context.runs,
+        context.current_run,
+        context.previous_run,
+        context.current_rows,
+        context.run_index,
+        context.wishlist_pressure_map,
     )
 
 

--- a/tests/scrape_module/test_matrix_workflow.py
+++ b/tests/scrape_module/test_matrix_workflow.py
@@ -2,6 +2,7 @@
 """Tests for shared matrix workflow helpers used by breeder/dealer builders."""
 
 from scrape.matrix_workflow import (
+    MatrixContext,
     collect_lookback_values_for_key,
     generate_price_wishlist_sparklines,
     get_wishlist_display_metrics,
@@ -61,6 +62,40 @@ class TestPrepareMatrixAnalysis:
         assert current_rows == by_run[current_run]
         assert run_index == {"2025-01-01": 0, "2025-01-08": 1}
         assert wishlist_pressure_map[("Aphonopelma seemanni", "1.0")] in {"🔥", "⚠️", "❌"}
+
+
+class TestMatrixContext:
+    """Dataclass wrapper for shared matrix builder context."""
+
+    def test_from_history_returns_none_for_insufficient_runs(self):
+        history = [make_row("2025-01-01", "Aphonopelma seemanni", "1.0", "25.00", "5")]
+
+        assert MatrixContext.from_history(history) is None
+
+    def test_from_history_builds_previous_and_current_maps(self):
+        history = [
+            make_row("2025-01-01", "Aphonopelma seemanni", "1.0", "25.00", "5"),
+            make_row("2025-01-01", "Grammostola pulchra", "2.0", "40.00", "2"),
+            make_row("2025-01-08", "Aphonopelma seemanni", "1.0", "26.00", "11"),
+            make_row("2025-01-08", "Brachypelma hamorii", "3.0", "55.00", "3"),
+        ]
+
+        context = MatrixContext.from_history(history)
+
+        assert context is not None
+        assert context.runs == ["2025-01-01", "2025-01-08"]
+        assert context.current_run == "2025-01-08"
+        assert context.previous_run == "2025-01-01"
+        assert context.run_index == {"2025-01-01": 0, "2025-01-08": 1}
+        assert set(context.current_map) == {
+            ("Aphonopelma seemanni", "1.0"),
+            ("Brachypelma hamorii", "3.0"),
+        }
+        assert set(context.previous_map) == {
+            ("Aphonopelma seemanni", "1.0"),
+            ("Grammostola pulchra", "2.0"),
+        }
+        assert context.wishlist_pressure_map[("Aphonopelma seemanni", "1.0")] in {"🔥", "⚠️", "❌"}
 
 
 class TestWishlistDisplayMetrics:


### PR DESCRIPTION
## Summary
- add a shared MatrixContext dataclass for matrix builder initialization
- refactor breeder and dealer matrix builders to use the shared context
- add unit tests covering MatrixContext.from_history

## Testing
- make test-file FILE=tests/scrape_module/test_matrix_workflow.py
- make test
- .venv/bin/python scripts/check_coverage.py --module=scrape/matrix_workflow.py
- .venv/bin/python scripts/check_coverage.py --module=scrape/breeder_matrix.py
- .venv/bin/python scripts/check_coverage.py --module=scrape/dealer_matrix.py

Closes #128