### PR TITLE
Deduplicate shared filter config defaults for issue 141

### DIFF
--- a/client/src/breeder-page/config.ts
+++ b/client/src/breeder-page/config.ts
@@ -1,4 +1,5 @@
 import type { SortableTablePageConfig } from '../shared/page-init.js';
+import { createFilterConfig } from '../shared/filter-config.js';
 
 export const BREEDER_PAGE_CONFIG: SortableTablePageConfig = {
   tableId: 'breeder-table',
@@ -16,13 +17,9 @@ export const BREEDER_PAGE_CONFIG: SortableTablePageConfig = {
     { key: 'Recommendation' },
     { key: 'Drivers', hidden: true },
   ],
-  filterConfig: {
+  filterConfig: createFilterConfig({
     signalFilter: { column: 'Signal', top10: true },
     stockPatternFilter: { column: 'Stock Pattern' },
-    priceColumn: 'Price',
-    wishlistColumn: 'Wishlist',
-    showSearch: true,
-    statsLabel: 'species',
     driversKey: 'Drivers',
-  },
+  }),
 };

--- a/client/src/dealer-page/config.ts
+++ b/client/src/dealer-page/config.ts
@@ -1,4 +1,5 @@
 import type { SortableTablePageConfig } from '../shared/page-init.js';
+import { createFilterConfig } from '../shared/filter-config.js';
 
 export const DEALER_PAGE_CONFIG: SortableTablePageConfig = {
   tableId: 'dealer-table',
@@ -17,12 +18,8 @@ export const DEALER_PAGE_CONFIG: SortableTablePageConfig = {
     { key: 'Dealer Recommendation' },
     { key: 'Drivers', hidden: true },
   ],
-  filterConfig: {
+  filterConfig: createFilterConfig({
     signalFilter: { column: 'Dealer Risk', top10: true },
-    priceColumn: 'Price',
-    wishlistColumn: 'Wishlist',
-    showSearch: true,
-    statsLabel: 'species',
     driversKey: 'Drivers',
-  },
+  }),
 };

--- a/client/src/shared/filter-config.test.ts
+++ b/client/src/shared/filter-config.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFilterConfig } from './filter-config.js';
+
+describe('createFilterConfig', () => {
+  it('applies the shared sortable table filter defaults', () => {
+    expect(createFilterConfig()).toEqual({
+      priceColumn: 'Price',
+      wishlistColumn: 'Wishlist',
+      showSearch: true,
+      statsLabel: 'species',
+    });
+  });
+
+  it('allows page-specific overrides on top of the shared defaults', () => {
+    expect(
+      createFilterConfig({
+        signalFilter: { column: 'Signal', top10: true },
+        stockPatternFilter: { column: 'Stock Pattern' },
+        driversKey: 'Drivers',
+      }),
+    ).toEqual({
+      signalFilter: { column: 'Signal', top10: true },
+      stockPatternFilter: { column: 'Stock Pattern' },
+      priceColumn: 'Price',
+      wishlistColumn: 'Wishlist',
+      showSearch: true,
+      statsLabel: 'species',
+      driversKey: 'Drivers',
+    });
+  });
+
+  it('supports alternate source columns for pages that use raw CSV headings', () => {
+    expect(
+      createFilterConfig({
+        priceColumn: 'Price (GBP)',
+        wishlistColumn: 'Wishlist Count',
+      }),
+    ).toEqual({
+      priceColumn: 'Price (GBP)',
+      wishlistColumn: 'Wishlist Count',
+      showSearch: true,
+      statsLabel: 'species',
+    });
+  });
+});

--- a/client/src/shared/filter-config.ts
+++ b/client/src/shared/filter-config.ts
@@ -1,0 +1,17 @@
+import type { FilterConfig } from './components/SortableTable.svelte';
+
+const DEFAULT_FILTER_CONFIG = {
+  priceColumn: 'Price',
+  wishlistColumn: 'Wishlist',
+  showSearch: true,
+  statsLabel: 'species',
+} satisfies Required<
+  Pick<FilterConfig, 'priceColumn' | 'wishlistColumn' | 'showSearch' | 'statsLabel'>
+>;
+
+export function createFilterConfig(overrides: Partial<FilterConfig> = {}): FilterConfig {
+  return {
+    ...DEFAULT_FILTER_CONFIG,
+    ...overrides,
+  };
+}

--- a/client/src/snapshot-page/config.ts
+++ b/client/src/snapshot-page/config.ts
@@ -1,4 +1,5 @@
 import type { SortableTablePageConfig } from '../shared/page-init.js';
+import { createFilterConfig } from '../shared/filter-config.js';
 
 export const SNAPSHOT_PAGE_CONFIG: SortableTablePageConfig = {
   tableId: 'snapshot-table',
@@ -9,11 +10,9 @@ export const SNAPSHOT_PAGE_CONFIG: SortableTablePageConfig = {
     { key: 'Price (GBP)' },
     { key: 'Wishlist Count' },
   ],
-  filterConfig: {
+  filterConfig: createFilterConfig({
     priceColumn: 'Price (GBP)',
     wishlistColumn: 'Wishlist Count',
-    showSearch: true,
-    statsLabel: 'species',
-  },
+  }),
   primaryToggle: true,
 };


### PR DESCRIPTION
## Summary
- add a shared `createFilterConfig()` helper for sortable-table page configs
- switch breeder, dealer, and snapshot page configs to compose through the shared defaults
- add direct test coverage for the new helper and keep the existing config stability assertions green

## Triage
- implemented #141
- closed #144 separately because the shared observation coverage formatter is already on current `master`

## Validation
- make test-client-file FILE=src/shared/filter-config.test.ts
- make test-client-file FILE=src/shared/page-init.test.ts
- make test-client
- make test-e2e

Closes #141