### PR TITLE
Document bounded price lookback in methodology

### DIFF
--- a/src/website/analysis_methodology.py
+++ b/src/website/analysis_methodology.py
@@ -61,6 +61,10 @@ def _shared_window_items() -> list[dict[str, str]]:
             "detail": "OUT rows can inherit their most recent in-stock wishlist pressure for a bounded period.",
         },
         {
+            "label": f"Price display lookback: {OOS_CARRYOVER_LOOKBACK} runs",
+            "detail": "OUT rows can also inherit their most recent in-stock price for the same bounded period. If no qualifying price is found inside that window, the Price cell falls back to N/A rather than using stale history.",
+        },
+        {
             "label": f"Current delta lookup window: {WISHLIST_DELTA_LOOKBACK} runs",
             "detail": "When a species is OUT now, momentum uses only a short carryover window.",
         },

--- a/tests/website_module/test_analysis_methodology.py
+++ b/tests/website_module/test_analysis_methodology.py
@@ -73,6 +73,10 @@ class TestAnalysisMethodologyBuilder:
             for line in threshold_lines
         )
         assert any(
+            f"Price display lookback: {OOS_CARRYOVER_LOOKBACK} runs" in line
+            for line in threshold_lines
+        )
+        assert any(
             f"Small-N flattening: max-min <= {WISHLIST_SMALL_N_FLATTEN_THRESHOLD}" in line
             for line in threshold_lines
         )
@@ -253,6 +257,10 @@ class TestAnalysisMethodologyBuilder:
             "Dealer Limited History",
             "Dealer price pressure",
         ]
+        assert any(
+            f"Price display lookback: {OOS_CARRYOVER_LOOKBACK} runs" in item["label"]
+            for item in dealer_windows_card["items"]
+        )
 
         medium_branch = next(
             branch for branch in tree_tab["tree"]["branches"] if branch["label"] == "If Medium"


### PR DESCRIPTION
## Summary
- disclose the bounded price display lookback in the methodology windows section
- cover the new disclosure in breeder and dealer methodology tests
- keep the wording aligned with the existing bounded-history terminology

## Testing
- make test
- make test-e2e