### PR TITLE
fix(lineage): explain neutralized demand and multi-variant price in Drivers

### DIFF
--- a/src/scrape/breeder_matrix.py
+++ b/src/scrape/breeder_matrix.py
@@ -7,7 +7,7 @@ from shared.history_utils import (
     k2,
 )
 from shared.config import BREEDER_TABLE_FILE, OOS_CARRYOVER_LOOKBACK, SIGNAL_PRIORITY
-from shared.driver_text_helpers import build_drivers_text
+from shared.driver_text_helpers import build_drivers_text, lineage_driver_overrides
 from shared.price_text_helpers import format_price_cell
 from shared.summary_utils import MatrixOutputConfig, write_matrix_outputs
 from scrape.matrix_workflow import (
@@ -58,11 +58,16 @@ def _generate_breeder_drivers_text(
     wishlist_delta: str,
     observation_coverage_text: str = "",
     lineage_clause: str = "",
+    lineage_status: str = "none",
 ) -> str:
     """Generate structured explanation of signal drivers using semicolon separators.
 
     The optional *lineage_clause* is appended after the standard three-section
     text when a size transition exists.
+
+    For ``multi-variant`` and ``ambiguous-transition`` lineage states the demand
+    and price sections include parenthetical qualifiers that explain why certain
+    values are forced neutral or suppressed.
 
     Returns:
         Semicolon-separated string explaining the signal drivers.
@@ -82,7 +87,13 @@ def _generate_breeder_drivers_text(
     if observation_coverage_text:
         stock_section = f"{stock_section}; Coverage: {observation_coverage_text}"
 
-    drivers = build_drivers_text(stock_section, price_trend, wishlist_pressure, wishlist_delta)
+    demand_qualifier, price_override = lineage_driver_overrides(lineage_status)
+
+    drivers = build_drivers_text(
+        stock_section, price_trend, wishlist_pressure, wishlist_delta,
+        demand_qualifier=demand_qualifier,
+        price_override=price_override,
+    )
 
     if lineage_clause:
         drivers = f"{drivers}; {lineage_clause}"
@@ -237,6 +248,7 @@ def build_breeder_opportunity_table(history_rows):
             wishlist_delta=wishlist_delta,
             observation_coverage_text=observation_coverage_text,
             lineage_clause=lineage_clause,
+            lineage_status=lineage_status,
         )
 
         table.append({

--- a/src/scrape/dealer_matrix.py
+++ b/src/scrape/dealer_matrix.py
@@ -10,7 +10,7 @@ from shared.history_utils import (
 )
 from shared.config import DEALER_TABLE_FILE, OOS_CARRYOVER_LOOKBACK
 from shared.sparkline_helpers import generate_species_stock_availability_sparkline
-from shared.driver_text_helpers import build_drivers_text
+from shared.driver_text_helpers import build_drivers_text, lineage_driver_overrides
 from shared.price_text_helpers import format_price_cell
 from shared.summary_utils import MatrixOutputConfig, write_matrix_outputs
 from scrape.matrix_workflow import (
@@ -42,10 +42,23 @@ def _generate_dealer_drivers_text(
     wishlist_pressure: str,
     wishlist_delta: str,
     lineage_clause: str = "",
+    lineage_status: str = "none",
 ) -> str:
-    """Generate structured explanation of risk drivers using semicolon separators."""
+    """Generate structured explanation of risk drivers using semicolon separators.
+
+    For ``multi-variant`` and ``ambiguous-transition`` lineage states the demand
+    and price sections include parenthetical qualifiers that explain why certain
+    values are forced neutral or suppressed.
+    """
     stock_section = f"Stock: Reliability {reliability} (Restock {speed})"
-    drivers = build_drivers_text(stock_section, price_pressure, wishlist_pressure, wishlist_delta)
+
+    demand_qualifier, price_override = lineage_driver_overrides(lineage_status)
+
+    drivers = build_drivers_text(
+        stock_section, price_pressure, wishlist_pressure, wishlist_delta,
+        demand_qualifier=demand_qualifier,
+        price_override=price_override,
+    )
     if lineage_clause:
         drivers = f"{drivers}; {lineage_clause}"
     return drivers
@@ -186,6 +199,7 @@ def build_dealer_supply_risk_table(history_rows):
             wishlist_pressure=wishlist_pressure,
             wishlist_delta=wishlist_delta,
             lineage_clause=lineage_clause,
+            lineage_status=lineage_status,
         )
 
         table.append({

--- a/src/shared/driver_text_helpers.py
+++ b/src/shared/driver_text_helpers.py
@@ -56,17 +56,25 @@ def format_price_trend(price_trend: str) -> str:
     return PRICE_TEXT.get(price_trend, price_trend)
 
 
-def build_demand_section(wishlist_pressure: str, wishlist_delta: str) -> str:
+def build_demand_section(wishlist_pressure: str, wishlist_delta: str, qualifier: str = "") -> str:
     """Build standardized demand section for driver text.
 
     Args:
         wishlist_pressure: Demand level (🔥/⚠️/❌)
         wishlist_delta: Momentum (↑/→/↓)
+        qualifier: Optional parenthetical context when the delta is forced neutral
+            (e.g. ``"momentum neutralized; continuity unconfirmed"``).  When
+            provided the standard ``"+ delta_text"`` suffix is replaced with
+            ``"(<qualifier>)"``.
 
     Returns:
-        Formatted demand section (e.g., "Demand: Wishlist High + rising")
+        Formatted demand section (e.g., "Demand: Wishlist High + rising" or
+        "Demand: Wishlist High (momentum neutralized; continuity unconfirmed)")
     """
-    return f"Demand: Wishlist {format_wishlist_pressure(wishlist_pressure)} + {format_delta(wishlist_delta)}"
+    pressure_text = format_wishlist_pressure(wishlist_pressure)
+    if qualifier:
+        return f"Demand: Wishlist {pressure_text} ({qualifier})"
+    return f"Demand: Wishlist {pressure_text} + {format_delta(wishlist_delta)}"
 
 
 def build_price_section(price_trend: str) -> str:
@@ -81,7 +89,34 @@ def build_price_section(price_trend: str) -> str:
     return f"Price: {format_price_trend(price_trend)}"
 
 
-def build_drivers_text(stock_section: str, price_trend: str, wishlist_pressure: str, wishlist_delta: str) -> str:
+def lineage_driver_overrides(lineage_status: str) -> tuple[str, str]:
+    """Return ``(demand_qualifier, price_override)`` for a given lineage status.
+
+    Centralises the mapping so neither breeder nor dealer matrix needs to
+    duplicate the same ``if/elif`` block.
+
+    Returns:
+        ``demand_qualifier`` — passed to :func:`build_demand_section` to replace
+        the standard ``"+ delta"`` suffix with a parenthetical explanation.
+
+        ``price_override`` — when non-empty, replaces the standard
+        ``"Price: <trend>"`` string entirely.
+    """
+    if lineage_status == "multi-variant":
+        return "active variants overlap; delta neutralized", "Price: Multiple active sizes"
+    if lineage_status == "ambiguous-transition":
+        return "momentum neutralized; continuity unconfirmed", ""
+    return "", ""
+
+
+def build_drivers_text(
+    stock_section: str,
+    price_trend: str,
+    wishlist_pressure: str,
+    wishlist_delta: str,
+    demand_qualifier: str = "",
+    price_override: str = "",
+) -> str:
     """Build standardized drivers text combining stock, demand, and price sections.
 
     Args:
@@ -89,11 +124,16 @@ def build_drivers_text(stock_section: str, price_trend: str, wishlist_pressure: 
         price_trend: Price direction (↑/→/↓)
         wishlist_pressure: Demand level (🔥/⚠️/❌)
         wishlist_delta: Momentum (↑/→/↓)
+        demand_qualifier: Optional qualifier passed through to
+            :func:`build_demand_section` — replaces the standard delta suffix
+            with a parenthetical explanation.
+        price_override: When non-empty, replaces the standard
+            ``"Price: <trend>"`` text entirely (e.g. ``"Price: Multiple active sizes"``).
 
     Returns:
         Semicolon-separated driver explanation
         (e.g., "Stock: Emerging (OOS 2 runs); Demand: Wishlist High + rising; Price: Stable")
     """
-    demand_section = build_demand_section(wishlist_pressure, wishlist_delta)
-    price_section = build_price_section(price_trend)
+    demand_section = build_demand_section(wishlist_pressure, wishlist_delta, demand_qualifier)
+    price_section = price_override if price_override else build_price_section(price_trend)
     return f"{stock_section}; {demand_section}; {price_section}"

--- a/tests/scrape_module/test_breeder_matrix.py
+++ b/tests/scrape_module/test_breeder_matrix.py
@@ -1155,6 +1155,15 @@ class TestBreederPhase4AcceptanceScenarios:
         assert "→" in row["Wishlist"]
         assert "↑" not in row["Wishlist"]
 
+    def test_scenario_b_drivers_explain_ambiguous_demand(self):
+        """Ambiguous transition: Drivers demand section must explain neutralized delta."""
+        rows = [r for r in build_breeder_opportunity_table(self._history_b())
+                if r["Species"] == self._SCI_B]
+        drivers = rows[0]["Drivers"]
+        assert "momentum neutralized; continuity unconfirmed" in drivers, (
+            f"Expected ambiguous demand qualifier in Drivers, got: {drivers!r}"
+        )
+
     # ── Scenario C: multi-variant (overlapping sizes) ───────────────────────
 
     _SCI_C = "Phase4 Breeder Overlap"
@@ -1185,6 +1194,19 @@ class TestBreederPhase4AcceptanceScenarios:
         assert row["Price History"] == "-"
         assert row["Wishlist History"] == "-"
         assert row["Signal"] == "❌"
+
+    def test_scenario_c_drivers_explain_multi_variant_price_and_demand(self):
+        """Multi-variant: Drivers price section must say 'Multiple active sizes',
+        demand must explain overlapping variants."""
+        rows = [r for r in build_breeder_opportunity_table(self._history_c())
+                if r["Species"] == self._SCI_C]
+        drivers = rows[0]["Drivers"]
+        assert "Price: Multiple active sizes" in drivers, (
+            f"Expected 'Price: Multiple active sizes' in Drivers, got: {drivers!r}"
+        )
+        assert "active variants overlap; delta neutralized" in drivers, (
+            f"Expected multi-variant demand qualifier in Drivers, got: {drivers!r}"
+        )
 
     # ── Scenario D: stable single-size species (regression guard) ───────────
 

--- a/tests/scrape_module/test_dealer_matrix.py
+++ b/tests/scrape_module/test_dealer_matrix.py
@@ -1420,6 +1420,14 @@ class TestDealerPhase4AcceptanceScenarios:
         assert "→" in row["Wishlist"]
         assert "↑" not in row["Wishlist"]
 
+    def test_scenario_b_drivers_explain_ambiguous_demand(self):
+        """Ambiguous transition: Drivers demand section must explain neutralized delta."""
+        rows = [r for r in _build_dealer(self._history_b()) if r["Species"] == self._SCI_B]
+        drivers = rows[0]["Drivers"]
+        assert "momentum neutralized; continuity unconfirmed" in drivers, (
+            f"Expected ambiguous demand qualifier in Drivers, got: {drivers!r}"
+        )
+
     # ── Scenario C: multi-variant ────────────────────────────────────────────
 
     _SCI_C = "Phase4 Dealer Overlap"
@@ -1445,6 +1453,18 @@ class TestDealerPhase4AcceptanceScenarios:
         assert row["Price History"] == "-"
         assert row["Wishlist History"] == "-"
         assert row["Dealer Risk"] == "❌"
+
+    def test_scenario_c_drivers_explain_multi_variant_price_and_demand(self):
+        """Multi-variant: Drivers price section must say 'Multiple active sizes',
+        demand must explain overlapping variants."""
+        rows = [r for r in _build_dealer(self._history_c()) if r["Species"] == self._SCI_C]
+        drivers = rows[0]["Drivers"]
+        assert "Price: Multiple active sizes" in drivers, (
+            f"Expected 'Price: Multiple active sizes' in Drivers, got: {drivers!r}"
+        )
+        assert "active variants overlap; delta neutralized" in drivers, (
+            f"Expected multi-variant demand qualifier in Drivers, got: {drivers!r}"
+        )
 
     # ── Scenario D: stable single-size (regression guard) ───────────────────
 

--- a/tests/shared_module/test_driver_text_helpers.py
+++ b/tests/shared_module/test_driver_text_helpers.py
@@ -7,6 +7,7 @@ from shared.driver_text_helpers import (
     build_demand_section,
     build_price_section,
     build_drivers_text,
+    lineage_driver_overrides,
 )
 
 
@@ -72,6 +73,19 @@ class TestBuildDemandSection:
     def test_falls_back_to_raw_values_for_unknown_inputs(self):
         assert build_demand_section("X", "Y") == "Demand: Wishlist X + Y"
 
+    def test_qualifier_replaces_delta_suffix(self):
+        """When qualifier is provided, it appears in parens instead of '+ delta'."""
+        result = build_demand_section("🔥", "→", qualifier="momentum neutralized; continuity unconfirmed")
+        assert result == "Demand: Wishlist High (momentum neutralized; continuity unconfirmed)"
+
+    def test_qualifier_multi_variant(self):
+        result = build_demand_section("🔥", "→", qualifier="active variants overlap; delta neutralized")
+        assert result == "Demand: Wishlist High (active variants overlap; delta neutralized)"
+
+    def test_empty_qualifier_uses_standard_format(self):
+        """Passing an empty qualifier string falls back to the standard format."""
+        assert build_demand_section("🔥", "↑", qualifier="") == "Demand: Wishlist High + rising"
+
 
 class TestBuildPriceSection:
     """Test price section builder."""
@@ -86,6 +100,26 @@ class TestBuildPriceSection:
 
     def test_falls_back_to_raw_value_for_unknown_input(self):
         assert build_price_section("X") == "Price: X"
+
+
+class TestLineageDriverOverrides:
+    """Test lineage_driver_overrides — centralised derivation of demand/price qualifiers."""
+
+    def test_multi_variant_returns_both_overrides(self):
+        demand_q, price_o = lineage_driver_overrides("multi-variant")
+        assert demand_q == "active variants overlap; delta neutralized"
+        assert price_o == "Price: Multiple active sizes"
+
+    def test_ambiguous_transition_returns_demand_qualifier_only(self):
+        demand_q, price_o = lineage_driver_overrides("ambiguous-transition")
+        assert demand_q == "momentum neutralized; continuity unconfirmed"
+        assert price_o == ""
+
+    @pytest.mark.parametrize("status", ["none", "confirmed-transition", "", "unknown"])
+    def test_no_override_for_other_statuses(self, status):
+        demand_q, price_o = lineage_driver_overrides(status)
+        assert demand_q == ""
+        assert price_o == ""
 
 
 class TestBuildDriversText:
@@ -117,3 +151,49 @@ class TestBuildDriversText:
             wishlist_delta="↑",
         )
         assert result == "Stock: Reliability Low (Restock Slow); Demand: Wishlist Moderate + rising; Price: Rising"
+
+    def test_demand_qualifier_replaces_delta_suffix(self):
+        """demand_qualifier is forwarded to build_demand_section."""
+        result = build_drivers_text(
+            stock_section="Stock: Emerging (OOS 2 runs; currently OUT)",
+            price_trend="→",
+            wishlist_pressure="🔥",
+            wishlist_delta="→",
+            demand_qualifier="momentum neutralized; continuity unconfirmed",
+        )
+        assert result == (
+            "Stock: Emerging (OOS 2 runs; currently OUT); "
+            "Demand: Wishlist High (momentum neutralized; continuity unconfirmed); "
+            "Price: Stable"
+        )
+
+    def test_price_override_replaces_price_section(self):
+        """price_override replaces the Price section entirely."""
+        result = build_drivers_text(
+            stock_section="Stock: Always (currently IN)",
+            price_trend="→",
+            wishlist_pressure="🔥",
+            wishlist_delta="→",
+            price_override="Price: Multiple active sizes",
+        )
+        assert result == (
+            "Stock: Always (currently IN); "
+            "Demand: Wishlist High + stable; "
+            "Price: Multiple active sizes"
+        )
+
+    def test_demand_qualifier_and_price_override_together(self):
+        """Both overrides active simultaneously (multi-variant case)."""
+        result = build_drivers_text(
+            stock_section="Stock: Always (currently IN)",
+            price_trend="→",
+            wishlist_pressure="🔥",
+            wishlist_delta="→",
+            demand_qualifier="active variants overlap; delta neutralized",
+            price_override="Price: Multiple active sizes",
+        )
+        assert result == (
+            "Stock: Always (currently IN); "
+            "Demand: Wishlist High (active variants overlap; delta neutralized); "
+            "Price: Multiple active sizes"
+        )


### PR DESCRIPTION
## Summary

Fixes two Drivers-column explainability gaps identified during a post-implementation review against the SIZE_VARIANT_IDENTITY_REQUIREMENTS.

### Discrepancy 1 — ambiguous-transition hid neutralized demand delta
Previously the Drivers column emitted `Demand: Wishlist X + stable` for `ambiguous-transition` species even though the delta was force-neutralised because continuity could not be confirmed across the size-transition boundary.

**Fix:** demand section now reads `Demand: Wishlist X (momentum neutralized; continuity unconfirmed)`.

### Discrepancy 2 — multi-variant showed misleading single price trend
For `multi-variant` species (which have multiple active price points) the Drivers column emitted `Price: Stable` — referencing a single-trend arrow that is meaningless when several sizes are simultaneously in stock.

**Fix:**
- Price section replaced with `Price: Multiple active sizes`
- Demand section gains `(active variants overlap; delta neutralized)`

## Implementation

- `build_demand_section()` gains optional `qualifier` param — replaces the standard `+ delta` suffix with a parenthetical explanation.
- `build_drivers_text()` passes through `demand_qualifier` and `price_override`.
- A single pure helper `lineage_driver_overrides()` in `driver_text_helpers.py` derives both values from the lineage status, so neither matrix duplicates the derivation logic.

## Tests

All new code paths covered:
- `TestLineageDriverOverrides` in `test_driver_text_helpers.py` (3 tests)
- Qualifier behaviour added to `TestBuildDemandSection` and `TestBuildDriversText`
- Scenario B & C driver-text assertions in `test_breeder_matrix.py` and `test_dealer_matrix.py`

830 tests pass, 157 skipped. Coverage: `driver_text_helpers` 100 %, `breeder_matrix` 97 %, `dealer_matrix` 98 %.