### PR TITLE
Fix ValueError when size_cm is empty string in build_chart_data

### DIFF
--- a/src/website/species_detail.py
+++ b/src/website/species_detail.py
@@ -248,7 +248,7 @@ def build_chart_data(
                 "observed": True,
                 "price": observations[run_date]["price"],
                 "wishlist": observations[run_date]["wishlist"],
-                "size": ", ".join(f"{float(s):g}" for s in sizes)
+                "size": ", ".join(f"{float(s):g}" for s in sizes if s.strip())
             })
         else:
             # Gap: species was NOT observed in this run (out of stock)

--- a/tests/website_module/test_species_detail.py
+++ b/tests/website_module/test_species_detail.py
@@ -347,6 +347,29 @@ class TestBuildChartData:
         finally:
             Path(history_csv).unlink()
 
+    def test_handles_empty_size_cm_without_raising(self):
+        """Should not raise ValueError when size_cm is an empty string in history CSV."""
+        from website.species_detail import build_chart_data
+
+        # Reproduces the production failure: size_cm field is blank in the CSV
+        content = (
+            "scrape_datetime,scientific_name,common_name,size_cm,price_gbp,wishlist_count,page_url\n"
+            "2025-01-01 06:00:00,Aphonopelma seemanni,Costa Rican Zebra,,10.00,5,http://example.com\n"
+        )
+        history_csv = create_temp_csv_file(content)
+
+        try:
+            # Must not raise ValueError: could not convert string to float: ''
+            chart_data = build_chart_data("Aphonopelma seemanni", history_csv)
+
+            assert len(chart_data["runs"]) == 1
+            run = chart_data["runs"][0]
+            assert run["observed"] is True
+            # Empty size_cm values should be excluded from the size string
+            assert run["size"] == ""
+        finally:
+            Path(history_csv).unlink()
+
 
 class TestGetDefaultSize:
     """Test default size selection from most recent observation."""


### PR DESCRIPTION
## Root Cause

The last two "Deploy to GitHub Pages" workflow runs failed with:

```
ValueError: could not convert string to float: ''
  File "src/website/species_detail.py", line 251, in build_chart_data
    "size": ", ".join(f"{float(s):g}" for s in sizes)
```

When a history CSV row has a blank `size_cm` field, `float('')` raises `ValueError`. The `sizes` list was not filtering empty strings before the float conversion.

## Fix

Added a `.strip()` guard in the generator expression in `build_chart_data()`:

```python
# Before
"size": ", ".join(f"{float(s):g}" for s in sizes)

# After
"size": ", ".join(f"{float(s):g}" for s in sizes if s.strip())
```

## Tests

Added `TestBuildChartData::test_handles_empty_size_cm_without_raising` which reproduces the exact production failure (CSV row with blank `size_cm`), confirmed it failed before the fix, and passes after.