### PR TITLE
fix: update breadcrumb origin when switching views on species page

### DIFF
--- a/client/src/species-page/index.ts
+++ b/client/src/species-page/index.ts
@@ -6,10 +6,38 @@
 
 import { renderCharts } from './charts.js';
 
+type View = 'breeder' | 'dealer';
+
+const VIEW_LABELS: Record<View, string> = {
+  breeder: 'Breeder',
+  dealer: 'Dealer',
+};
+
+const VIEW_HINTS: Record<View, string> = {
+  breeder: 'Breeder view: focuses on opportunity signals and scarcity.',
+  dealer: 'Dealer view: focuses on supply risk, reliability, and restock speed.',
+};
+
+function updateNavigationContext(view: View): void {
+  const backBreeder = document.getElementById('back-breeder');
+  const backDealer = document.getElementById('back-dealer');
+  if (backBreeder && backDealer) {
+    backBreeder.classList.toggle('origin-btn', view === 'breeder');
+    backDealer.classList.toggle('origin-btn', view === 'dealer');
+  }
+
+  const breadcrumbLink = document.querySelector('.breadcrumbs a') as HTMLAnchorElement | null;
+  if (breadcrumbLink) {
+    breadcrumbLink.textContent = VIEW_LABELS[view];
+    breadcrumbLink.href = breadcrumbLink.href.replace(/(?:breeder|dealer)\.html/, `${view}.html`);
+  }
+}
+
 function initTabSwitching(): void {
   document.querySelectorAll('[role="tab"]').forEach(tab => {
     tab.addEventListener('click', (e) => {
-      const view = (e.target as HTMLElement).dataset.view;
+      const view = (e.target as HTMLElement).dataset.view as View | undefined;
+      if (!view) return;
 
       document.querySelectorAll('[role="tab"]').forEach(t => {
         t.setAttribute('aria-selected', 'false');
@@ -23,20 +51,13 @@ function initTabSwitching(): void {
 
       const hint = document.getElementById('view-hint');
       if (hint) {
-        hint.textContent = view === 'breeder'
-          ? 'Breeder view: focuses on opportunity signals and scarcity.'
-          : 'Dealer view: focuses on supply risk, reliability, and restock speed.';
+        hint.textContent = VIEW_HINTS[view];
       }
 
-      const backBreeder = document.getElementById('back-breeder');
-      const backDealer = document.getElementById('back-dealer');
-      if (backBreeder && backDealer) {
-        backBreeder.classList.toggle('origin-btn', view === 'breeder');
-        backDealer.classList.toggle('origin-btn', view === 'dealer');
-      }
+      updateNavigationContext(view);
 
       const url = new URL(window.location.href);
-      url.searchParams.set('view', view ?? '');
+      url.searchParams.set('view', view);
       window.history.pushState({}, '', url);
     });
   });

--- a/tests/e2e/test_species_page_interactions.py
+++ b/tests/e2e/test_species_page_interactions.py
@@ -578,3 +578,78 @@ def test_species_detail_observation_coverage_emphasizes_key_dates(e2e_site_minim
         f"Latest observed should stay visually neutral unless stale, got border-left width {latest_border}"
 
 
+@pytest.mark.e2e
+def test_breadcrumb_reflects_dealer_origin_when_navigating_from_dealer_page(e2e_site_minimal) -> None:
+    """Breadcrumb should show Dealer as origin when navigating from the dealer page.
+
+    Bug: species pages are static HTML where default_view is baked in at generation time
+    (always 'breeder' if the species has breeder data). When a user arrives via a dealer
+    table link (?view=dealer), JavaScript switches the active tab but historically did
+    NOT update the breadcrumb, so it still showed 'Breeder → Species → ...' instead of
+    'Dealer → Species → ...'.
+    """
+    page, base_url, errors = e2e_site_minimal
+
+    # Navigate from dealer page — the species link includes ?view=dealer
+    page.goto(f"{base_url}/dealer.html", wait_until="domcontentloaded")
+    species_link = page.locator('table a[href^="species/"]').first
+    with page.expect_navigation():
+        species_link.click()
+
+    # Wait for JS to initialize (initViewFromURL clicks the dealer tab)
+    page.wait_for_timeout(200)
+
+    breadcrumb_link = page.locator('.breadcrumbs a').first
+    assert breadcrumb_link.inner_text().strip() == "Dealer", (
+        "Breadcrumb origin should read 'Dealer' when arriving from the dealer page, "
+        f"got: '{breadcrumb_link.inner_text().strip()}'"
+    )
+    assert "dealer.html" in breadcrumb_link.get_attribute("href"), (
+        "Breadcrumb link should point to dealer.html when arriving from the dealer page"
+    )
+
+
+@pytest.mark.e2e
+def test_breadcrumb_updates_when_switching_tabs(e2e_site_minimal) -> None:
+    """Breadcrumb origin should update dynamically when switching between Breeder/Dealer tabs."""
+    page, base_url, errors = e2e_site_minimal
+
+    # Start from breeder page
+    page.goto(f"{base_url}/breeder.html", wait_until="domcontentloaded")
+    species_link = page.locator('table a[href^="species/"]').first
+    with page.expect_navigation():
+        species_link.click()
+    page.wait_for_timeout(200)
+
+    breadcrumb_link = page.locator('.breadcrumbs a').first
+
+    # Initially: breeder origin
+    assert breadcrumb_link.inner_text().strip() == "Breeder", (
+        f"Breadcrumb should start as 'Breeder', got: '{breadcrumb_link.inner_text().strip()}'"
+    )
+    assert "breeder.html" in breadcrumb_link.get_attribute("href"), (
+        "Breadcrumb link should point to breeder.html initially"
+    )
+
+    # Switch to dealer tab
+    page.locator("#tab-dealer").click()
+    page.wait_for_timeout(100)
+
+    assert breadcrumb_link.inner_text().strip() == "Dealer", (
+        f"Breadcrumb should update to 'Dealer' after switching tab, got: '{breadcrumb_link.inner_text().strip()}'"
+    )
+    assert "dealer.html" in breadcrumb_link.get_attribute("href"), (
+        "Breadcrumb link should point to dealer.html after switching to dealer tab"
+    )
+
+    # Switch back to breeder tab
+    page.locator("#tab-breeder").click()
+    page.wait_for_timeout(100)
+
+    assert breadcrumb_link.inner_text().strip() == "Breeder", (
+        f"Breadcrumb should revert to 'Breeder' after switching back, got: '{breadcrumb_link.inner_text().strip()}'"
+    )
+    assert "breeder.html" in breadcrumb_link.get_attribute("href"), (
+        "Breadcrumb link should point to breeder.html after switching back to breeder tab"
+    )
+


### PR DESCRIPTION
## Problem

The breadcrumb on species detail pages was baked as static HTML at generation time, always defaulting to `Breeder` as the origin for any species with breeder data. When a user navigated from the dealer table (via a `?view=dealer` link), JavaScript correctly switched the active tab and panels, but the breadcrumb still showed:

```
Breeder → Species → Aphonopelma seemanni
```

instead of the correct:

```
Dealer → Species → Aphonopelma seemanni
```

## Fix

Extended `initTabSwitching()` in `client/src/species-page/index.ts` to update the breadcrumb text and `href` whenever the active view changes, via a new `updateNavigationContext()` helper that also manages back-button highlighting.

## Refactors (no behaviour change)

- Extract `updateNavigationContext(view)` grouping back-button highlight + breadcrumb update
- Use `VIEW_LABELS` / `VIEW_HINTS` lookup maps instead of inline ternary/conditional chains
- Replace chained string-replace with a single regex replace for the breadcrumb `href`
- Add early return guard when `dataset.view` is `undefined`
- Remove the now-redundant `view ?? ''` fallback in the `pushState` call

## Tests

Two new E2E tests added to `tests/e2e/test_species_page_interactions.py`:

- `test_breadcrumb_reflects_dealer_origin_when_navigating_from_dealer_page` — reproduces the bug
- `test_breadcrumb_updates_when_switching_tabs` — verifies breadcrumb updates dynamically on every tab switch