### PR TITLE
feat: surface JS bundle version in footer to diagnose SW cache staleness

### DIFF
--- a/.github/actions/build-client/action.yml
+++ b/.github/actions/build-client/action.yml
@@ -1,6 +1,12 @@
 name: Build Client Assets
 description: Set up Node.js and build Vite client-side assets into templates/scripts/dist/
 
+inputs:
+  build-version:
+    description: 'Build version string injected as __BUILD_VERSION__ (e.g. abc1234-r25523830085). Defaults to local-dev.'
+    required: false
+    default: 'local-dev'
+
 runs:
   using: composite
   steps:
@@ -14,3 +20,5 @@ runs:
     - name: Build client assets
       run: make build-client
       shell: bash
+      env:
+        VITE_BUILD_VERSION: ${{ inputs.build-version }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -125,8 +125,14 @@ jobs:
       # --------------------------------
       # Build client-side assets
       # --------------------------------
+      - name: Set build version
+        id: build-version
+        run: echo "value=$(git rev-parse --short HEAD)-r${GITHUB_RUN_ID}" >> $GITHUB_OUTPUT
+
       - name: Build client assets
         uses: ./.github/actions/build-client
+        with:
+          build-version: ${{ steps.build-version.outputs.value }}
 
       # --------------------------------
       # Generate static website

--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -3,6 +3,13 @@
  */
 
 /**
+ * Build version string injected by Vite at build time.
+ * Format: "{shortSha}-r{runId}" in CI (e.g. "abc1234-r25523830085").
+ * Falls back to "local-dev" when built locally without VITE_BUILD_VERSION set.
+ */
+declare const __BUILD_VERSION__: string;
+
+/**
  * Open structural type for a row read from a Python-generated table payload.
  * Deliberately wide because Python owns the column names and they differ per
  * page. TypeScript cannot enforce column names here — use assertPayload() in

--- a/client/src/sw-toast-entry.ts
+++ b/client/src/sw-toast-entry.ts
@@ -2,6 +2,17 @@ import { mount } from 'svelte';
 import SwUpdateToast from './shared/components/SwUpdateToast.svelte';
 import { useRegisterSW } from './shared/register-sw';
 
+// Expose the build version globally so DevTools console inspection and the
+// footer version element always reflect what the SW is actually serving.
+// If the SW is stuck on an old bundle, this value will be the OLD version —
+// that discrepancy between what's shown here and the latest deployed version
+// is the diagnostic signal we rely on.
+(window as Record<string, unknown>).__buildVersion = __BUILD_VERSION__;
+const versionEl = document.getElementById('site-version-display');
+if (versionEl) {
+  versionEl.textContent = __BUILD_VERSION__;
+}
+
 // Compute the SW URL at runtime from import.meta.url so it is correct in every
 // hosting context — local dev (http://localhost:PORT/sw.js) and GitHub Pages
 // subpath deployment (https://…/spidershop-historical-analysis/sw.js) alike.

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -132,6 +132,11 @@ export function createViteConfig(isCiBuild = !!process.env.CI): UserConfig {
       perFile: false,
     },
   },
+  // Inject build version at compile time. Set VITE_BUILD_VERSION in CI.
+  // Falls back to 'local-dev' for local builds.
+  define: {
+    __BUILD_VERSION__: JSON.stringify(process.env.VITE_BUILD_VERSION ?? 'local-dev'),
+  },
   build: {
     outDir: resolve(__dirname, '../templates/scripts/dist'),
     emptyOutDir: true,

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,6 +67,7 @@
         <p>Data scraped from <a href="https://thespidershop.co.uk/" target="_blank">The Spider Shop UK</a></p>
         <p><a href="https://github.com/christianacca/spidershop-historical-analysis" target="_blank">View on GitHub</a></p>
         <p>Generated: {{ timestamp }}</p>
+        <p class="site-version">JS bundle: <span id="site-version-display" title="Version of JavaScript bundle served by the Service Worker. Stays stale until SW updates.">—</span></p>
     </footer>
     
     {% block extra_js %}{% endblock %}


### PR DESCRIPTION
## Problem

After deploying the scroll restoration fix, the site appeared not to work on mobile — but only in the regular browser, not incognito. The root cause was the Service Worker serving a stale JS bundle. There was no way to tell whether the SW was serving the current or a stale version of the code.

## Solution

Inject the commit SHA + GitHub Actions run ID into the JS bundle at build time, and surface it in the site footer on every page.

### What was added

- **`VITE_BUILD_VERSION` env var** — set by `deploy-pages.yml` to `{shortSha}-r{runId}` (e.g. `676602b-r25523830085`) before the Vite build
- **`__BUILD_VERSION__` global constant** — injected by `vite.config.ts` `define` from the env var; falls back to `local-dev`
- **`sw-toast-entry.ts`** — writes the version to `window.__buildVersion` and populates `#site-version-display` in the footer
- **`base.html` footer** — adds `JS bundle: <span id="site-version-display">—</span>` (the `—` placeholder becomes the real version once JS loads)

### How to use it to verify SW health

1. Visit any page on the site on your device
2. Scroll to the footer — you will see `JS bundle: abc1234-r25523830085`
3. Share the version string here
4. I look up the corresponding commit/run on GitHub and confirm whether it matches the latest deployed version
5. If they differ → SW is serving stale JS; clearing site data is the fix
6. If they match → SW is up to date; scroll restoration should work

### Key property

The version comes from the **running JS bundle**, not from the HTML. If the SW is caching old JS, the footer will show the OLD version — that mismatch is exactly the diagnostic signal we need.

## Test results

- 534 client unit tests pass ✅
- 220 E2E tests pass ✅