### PR TITLE
feat: add HTML version to footer alongside JS bundle version

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -140,6 +140,7 @@ jobs:
       - name: Generate HTML website
         env:
           PYTHONPATH: ${{ github.workspace }}/src
+          BUILD_VERSION: ${{ steps.build-version.outputs.value }}
         run: |
           python -m website
 

--- a/src/website/html_utils.py
+++ b/src/website/html_utils.py
@@ -3,6 +3,7 @@
 This module provides the shared Jinja2 environment used by website generators.
 """
 
+import os
 from pathlib import Path
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
@@ -22,3 +23,7 @@ except ModuleNotFoundError:
     from page_config import NAV_ITEMS  # type: ignore[no-redef]
 
 jinja_env.globals['nav_items'] = NAV_ITEMS
+# Build version baked into HTML at generation time.  In CI this is the same
+# '{shortSha}-r{runId}' string injected into the JS bundle, so comparing the
+# two footer values immediately reveals which cache layer (HTML vs JS) is stale.
+jinja_env.globals['build_version'] = os.environ.get('BUILD_VERSION', 'local-dev')

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,7 +67,7 @@
         <p>Data scraped from <a href="https://thespidershop.co.uk/" target="_blank">The Spider Shop UK</a></p>
         <p><a href="https://github.com/christianacca/spidershop-historical-analysis" target="_blank">View on GitHub</a></p>
         <p>Generated: {{ timestamp }}</p>
-        <p class="site-version">JS bundle: <span id="site-version-display" title="Version of JavaScript bundle served by the Service Worker. Stays stale until SW updates.">—</span></p>
+        <p class="site-version">HTML: {{ build_version }} &nbsp;|&nbsp; JS bundle: <span id="site-version-display" title="Version of JavaScript bundle served by the Service Worker. Stays stale until SW updates.">—</span></p>
     </footer>
     
     {% block extra_js %}{% endblock %}


### PR DESCRIPTION
Footer now shows both HTML and JS bundle versions, revealing which cache layer is stale.