### PR TITLE
fix: move pagereveal to &lt;head&gt; and use shared jinja_env in species pages

### DIFF
--- a/client/src/sw-activate.test.ts
+++ b/client/src/sw-activate.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for the SW activate-time cache eviction logic.
+ *
+ * The logic lives in sw-activate.ts so it can be tested outside a
+ * ServiceWorkerGlobalScope.  sw.ts wires the pure predicate into the real
+ * Cache API during the activate event.
+ *
+ * Mutation targets exercised here:
+ * - Remove a page from buildMainPageSet → that page is now evicted (main-page
+ *   retention tests fail).
+ * - Replace `!mainPages.has(url)` with `mainPages.has(url)` → all tests invert:
+ *   main pages are evicted, species pages are kept.
+ * - Change the scope interpolation from `${scope}breeder.html` to `breeder.html`
+ *   (drop the scope prefix) → scoped-URL tests fail.
+ * - Rename `history-insights.html` to `history-insights-page.html` → the
+ *   history-insights retention test fails.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildMainPageSet, shouldEvictOnActivate } from './sw-activate.js';
+
+const SCOPE = 'https://example.github.io/spidershop/';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildMainPageSet
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildMainPageSet', () => {
+  it('contains exactly six main HTML pages', () => {
+    const pages = buildMainPageSet(SCOPE);
+    expect(pages.size).toBe(6);
+  });
+
+  it('contains index.html at the scope root', () => {
+    const pages = buildMainPageSet(SCOPE);
+    expect(pages.has(`${SCOPE}index.html`)).toBe(true);
+  });
+
+  it('contains breeder.html', () => {
+    const pages = buildMainPageSet(SCOPE);
+    expect(pages.has(`${SCOPE}breeder.html`)).toBe(true);
+  });
+
+  it('contains dealer.html', () => {
+    const pages = buildMainPageSet(SCOPE);
+    expect(pages.has(`${SCOPE}dealer.html`)).toBe(true);
+  });
+
+  it('contains snapshot.html', () => {
+    const pages = buildMainPageSet(SCOPE);
+    expect(pages.has(`${SCOPE}snapshot.html`)).toBe(true);
+  });
+
+  it('contains history.html', () => {
+    const pages = buildMainPageSet(SCOPE);
+    expect(pages.has(`${SCOPE}history.html`)).toBe(true);
+  });
+
+  it('contains history-insights.html', () => {
+    // This page is often forgotten because it is not in the primary nav.
+    // If it is evicted on activation the user gets a full network fetch,
+    // breaking the "fresh HTML before toast" guarantee.
+    const pages = buildMainPageSet(SCOPE);
+    expect(pages.has(`${SCOPE}history-insights.html`)).toBe(true);
+  });
+
+  it('does NOT contain species pages', () => {
+    const pages = buildMainPageSet(SCOPE);
+    expect(pages.has(`${SCOPE}species/aphonopelma-seemanni.html`)).toBe(false);
+  });
+
+  it('prefixes every entry with the scope', () => {
+    const scopeA = 'https://a.example.com/app/';
+    const scopeB = 'https://b.example.com/';
+    const pagesA = buildMainPageSet(scopeA);
+    const pagesB = buildMainPageSet(scopeB);
+    // All entries use the correct scope prefix, not each other's
+    for (const url of pagesA) {
+      expect(url.startsWith(scopeA)).toBe(true);
+      expect(pagesB.has(url)).toBe(false);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// shouldEvictOnActivate — main pages: KEEP (returns false)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('shouldEvictOnActivate — main pages are NOT evicted', () => {
+  const mainPages = [
+    'index.html',
+    'breeder.html',
+    'dealer.html',
+    'snapshot.html',
+    'history.html',
+    'history-insights.html',
+  ];
+
+  it.each(mainPages)('%s is retained (returns false)', (page) => {
+    const result = shouldEvictOnActivate(`${SCOPE}${page}`, SCOPE);
+    expect(result).toBe(false);
+  });
+
+  it('retains main pages with query strings unchanged (exact URL match)', () => {
+    // Cache keys are exact request URLs — a query string makes it a different entry
+    // so it would be evicted.  This confirms the Set comparison is exact.
+    const withQuery = shouldEvictOnActivate(`${SCOPE}breeder.html?v=1`, SCOPE);
+    expect(withQuery).toBe(true); // query string → NOT a main page → evicted
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// shouldEvictOnActivate — non-main pages: EVICT (returns true)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('shouldEvictOnActivate — non-main pages ARE evicted', () => {
+  it('evicts a species detail page', () => {
+    const result = shouldEvictOnActivate(
+      `${SCOPE}species/aphonopelma-seemanni.html`,
+      SCOPE,
+    );
+    expect(result).toBe(true);
+  });
+
+  it('evicts a species page at any slug', () => {
+    const slugs = [
+      'brachypelma-hamorii',
+      'tliltocatl-albopilosus',
+      'chromatopelma-cyaneopubescens',
+    ];
+    for (const slug of slugs) {
+      expect(shouldEvictOnActivate(`${SCOPE}species/${slug}.html`, SCOPE)).toBe(true);
+    }
+  });
+
+  it('evicts an unknown top-level HTML page not in the main set', () => {
+    // Defensively evicts anything that was cached but is not a known main page.
+    const result = shouldEvictOnActivate(`${SCOPE}unknown-page.html`, SCOPE);
+    expect(result).toBe(true);
+  });
+
+  it('evicts a page whose URL uses a different scope', () => {
+    // A cached entry from a prior scope (e.g. after a path change) must be evicted.
+    const staleUrl = 'https://old.example.com/spidershop/breeder.html';
+    const result = shouldEvictOnActivate(staleUrl, SCOPE);
+    expect(result).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Eviction result: correct subset of a mixed cache
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('eviction filter over a realistic html-pages cache snapshot', () => {
+  const cachedUrls = [
+    `${SCOPE}index.html`,
+    `${SCOPE}breeder.html`,
+    `${SCOPE}dealer.html`,
+    `${SCOPE}snapshot.html`,
+    `${SCOPE}history.html`,
+    `${SCOPE}history-insights.html`,
+    `${SCOPE}species/aphonopelma-seemanni.html`,
+    `${SCOPE}species/brachypelma-hamorii.html`,
+    `${SCOPE}species/grammostola-pulchripes.html`,
+  ];
+
+  const toEvict = cachedUrls.filter(url => shouldEvictOnActivate(url, SCOPE));
+  const toKeep = cachedUrls.filter(url => !shouldEvictOnActivate(url, SCOPE));
+
+  it('evicts exactly the three species pages', () => {
+    expect(toEvict).toHaveLength(3);
+    expect(toEvict).toContain(`${SCOPE}species/aphonopelma-seemanni.html`);
+    expect(toEvict).toContain(`${SCOPE}species/brachypelma-hamorii.html`);
+    expect(toEvict).toContain(`${SCOPE}species/grammostola-pulchripes.html`);
+  });
+
+  it('keeps exactly the six main pages', () => {
+    expect(toKeep).toHaveLength(6);
+  });
+
+  it('keeps every main page by name', () => {
+    const keptNames = toKeep.map(url => url.replace(SCOPE, ''));
+    expect(keptNames).toEqual(
+      expect.arrayContaining([
+        'index.html',
+        'breeder.html',
+        'dealer.html',
+        'snapshot.html',
+        'history.html',
+        'history-insights.html',
+      ]),
+    );
+  });
+
+  it('never evicts a main page', () => {
+    const evictedNames = toEvict.map(url => url.replace(SCOPE, ''));
+    for (const name of evictedNames) {
+      expect(name).toMatch(/^species\//);
+    }
+  });
+});

--- a/client/src/sw-activate.ts
+++ b/client/src/sw-activate.ts
@@ -1,0 +1,35 @@
+/**
+ * Activate-time cache eviction logic for the Service Worker.
+ *
+ * Extracted as a pure module so the eviction predicate can be unit-tested
+ * independently of the Workbox/ServiceWorkerGlobalScope environment.
+ */
+
+/** The canonical set of HTML pages that are safe to keep after a SW update.
+ *
+ * These six pages are pre-fetched during the install handler, so they are
+ * already fresh when activate runs.  Everything else (species detail pages, etc.)
+ * is lazily cached via StaleWhileRevalidate and must be evicted on every
+ * SW update so stale inline scripts in old HTML don't break view transitions.
+ */
+export function buildMainPageSet(scope: string): Set<string> {
+  return new Set([
+    `${scope}index.html`,
+    `${scope}breeder.html`,
+    `${scope}dealer.html`,
+    `${scope}snapshot.html`,
+    `${scope}history.html`,
+    `${scope}history-insights.html`,
+  ]);
+}
+
+/**
+ * Returns `true` when the cached entry at `url` should be evicted during SW activation.
+ *
+ * All html-pages cache entries that are NOT one of the six main pages are evicted.
+ * This ensures stale species-page HTML (which can contain an outdated inline
+ * pagereveal script from a previous deploy) is never served after a SW update.
+ */
+export function shouldEvictOnActivate(url: string, scope: string): boolean {
+  return !buildMainPageSet(scope).has(url);
+}

--- a/client/src/sw.ts
+++ b/client/src/sw.ts
@@ -77,7 +77,7 @@ self.addEventListener('activate', (event) => {
             .map(req => cache.delete(req)),
         ),
       ),
-    ),
+    ).then(() => self.clients.claim()),
   );
 });
 

--- a/client/src/sw.ts
+++ b/client/src/sw.ts
@@ -4,6 +4,7 @@ import { NavigationRoute, registerRoute } from 'workbox-routing';
 import { StaleWhileRevalidate } from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
 import type { PrecacheEntry } from 'workbox-precaching';
+import { shouldEvictOnActivate } from './sw-activate.js';
 
 declare const self: ServiceWorkerGlobalScope & { __WB_MANIFEST: Array<PrecacheEntry | string> };
 
@@ -67,20 +68,12 @@ self.addEventListener('install', (event) => {
 // the SW update — one small network hit, but always correct HTML.
 self.addEventListener('activate', (event) => {
   const scope = self.registration.scope;
-  const mainPages = new Set([
-    `${scope}index.html`,
-    `${scope}breeder.html`,
-    `${scope}dealer.html`,
-    `${scope}snapshot.html`,
-    `${scope}history.html`,
-    `${scope}history-insights.html`,
-  ]);
   event.waitUntil(
     caches.open('html-pages').then(cache =>
       cache.keys().then(keys =>
         Promise.all(
           keys
-            .filter(req => !mainPages.has(req.url))
+            .filter(req => shouldEvictOnActivate(req.url, scope))
             .map(req => cache.delete(req)),
         ),
       ),

--- a/src/website/species_detail.py
+++ b/src/website/species_detail.py
@@ -11,16 +11,10 @@ from typing import Optional, Dict, List, Tuple, Set
 from collections import defaultdict
 from datetime import datetime
 
-from jinja2 import Environment, FileSystemLoader
-
 from website.csv_utils import read_csv_file
+from website.html_utils import jinja_env
 from shared.history_utils import build_species_presence_timeline
 from shared.parsing import format_datetime_smart
-
-
-# Initialize Jinja2 environment
-template_dir = Path(__file__).parent.parent.parent / "templates"
-jinja_env = Environment(loader=FileSystemLoader(str(template_dir)))
 
 
 def slugify_species(scientific_name: str) -> str:

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,44 @@
     <link rel="manifest" href="{{ path_prefix }}manifest.webmanifest">
     <meta name="theme-color" content="#2c3e50">
     {% block extra_css %}{% endblock %}
+    <!-- pagereveal must be a classic parser-blocking script in <head>.
+         Per Chrome DevRel docs: "register the listener in a classic parser-blocking
+         script in the <head> (not a module, not async, not defer)", because
+         the event can fire before DOMContentLoaded, before any deferred scripts run. -->
+    <script>
+    (function () {
+      function isSpeciesPage(url) {
+        return !!url && /\/species\//.test(url);
+      }
+      window.addEventListener('pagereveal', function (e) {
+        var vt = e.viewTransition;
+        if (!vt) return;
+        var nav = window.navigation;
+        var act = nav && nav.activation;
+        if (!act || !act.from) return;
+        var fromSpecies = isSpeciesPage(act.from.url);
+        var toSpecies = isSpeciesPage(act.entry.url);
+        if (!fromSpecies && toSpecies) { vt.types.add('forward'); }
+        else if (fromSpecies && !toSpecies) {
+          vt.types.add('backward');
+          // Phase 1: restore scroll position saved by the listing page pagehide handler.
+          // Fires before the VT animation starts so the listing is already scrolled
+          // correctly when the species page slides off. Phase 2 (after Svelte mount)
+          // corrects the position if the skeleton was shorter than the full content.
+          try {
+            var key = 'vt-scroll:' + act.entry.url;
+            var savedY = sessionStorage.getItem(key);
+            if (savedY !== null) {
+              sessionStorage.removeItem(key);
+              var y = parseInt(savedY, 10);
+              window.__vtScrollRestoreY = y;
+              window.scrollTo({ top: y, behavior: 'instant' });
+            }
+          } catch (_) {}
+        }
+      });
+    }());
+    </script>
 </head>
 <body>
     <header>
@@ -74,44 +112,6 @@
 
     <div id="sw-update-toast-root"></div>
     <script type="module" src="{{ path_prefix }}sw-toast-entry.js"></script>
-    <!-- Inline classic script to avoid a render-blocking network request for ~15 lines.
-         Must NOT be type="module", defer, or async — those delay execution past the
-         pagereveal event (which fires before DOMContentLoaded). A synchronous external
-         script would also work but adds an unnecessary round-trip. -->
-    <script>
-    (function () {
-      function isSpeciesPage(url) {
-        return !!url && /\/species\//.test(url);
-      }
-      window.addEventListener('pagereveal', function (e) {
-        var vt = e.viewTransition;
-        if (!vt) return;
-        var nav = window.navigation;
-        var act = nav && nav.activation;
-        if (!act || !act.from) return;
-        var fromSpecies = isSpeciesPage(act.from.url);
-        var toSpecies = isSpeciesPage(act.entry.url);
-        if (!fromSpecies && toSpecies) { vt.types.add('forward'); }
-        else if (fromSpecies && !toSpecies) {
-          vt.types.add('backward');
-          // Phase 1: restore scroll position saved by the listing page pagehide handler.
-          // Fires before the VT animation starts so the listing is already scrolled
-          // correctly when the species page slides off. Phase 2 (after Svelte mount)
-          // corrects the position if the skeleton was shorter than the full content.
-          try {
-            var key = 'vt-scroll:' + act.entry.url;
-            var savedY = sessionStorage.getItem(key);
-            if (savedY !== null) {
-              sessionStorage.removeItem(key);
-              var y = parseInt(savedY, 10);
-              window.__vtScrollRestoreY = y;
-              window.scrollTo({ top: y, behavior: 'instant' });
-            }
-          } catch (_) {}
-        }
-      });
-    }());
-    </script>
     <script type="module" src="{{ path_prefix }}view-transitions-entry.js"></script>
     <script type="speculationrules">
 {"prefetch":[{"source":"document","eagerness":"moderate","where":{"href_matches":"species/*.html"}}]}

--- a/tests/e2e/test_pwa_sw.py
+++ b/tests/e2e/test_pwa_sw.py
@@ -601,3 +601,186 @@ def test_refresh_button_activates_new_sw(_e2e_sw_update_context) -> None:
         f"After Refresh, html-pages cache is missing: {missing_after}.\n"
         f"Cached: {cached_urls_after}"
     )
+
+
+@pytest.mark.e2e
+def test_install_does_not_cache_species_pages(e2e_site_minimal) -> None:
+    """The install handler must NOT pre-cache species detail pages.
+
+    Species pages contain an inline pagereveal script baked at HTML-generation time.
+    Pre-caching them during install would mean stale HTML with an outdated script
+    is served after a deploy until the user explicitly navigates to that species.
+    Keeping species pages out of the install cache ensures the activate handler can
+    evict any previous copy that was lazily cached, so the first post-update visit
+    always fetches fresh HTML.
+
+    Mutation targets:
+    - Add species pages to the install handler's `mainPages` array → species URLs
+      appear in html-pages immediately after install, test fails.
+    - Add a separate `caches.open('html-pages').then(cache => cache.put(speciesUrl, ...))` 
+      in the install handler → same failure.
+    """
+    page, base_url, _ = e2e_site_minimal
+
+    # Navigate once to activate the SW (do NOT visit any species page).
+    page.goto(f"{base_url}/breeder.html", wait_until="domcontentloaded")
+    page.evaluate("async () => { await navigator.serviceWorker.ready; }")
+
+    # Read all keys currently in the html-pages cache.
+    cached_urls: list[str] = page.evaluate("""
+        async () => {
+            const cache = await caches.open('html-pages');
+            const keys = await cache.keys();
+            return keys.map(r => r.url);
+        }
+    """)
+
+    species_in_cache = [u for u in cached_urls if "/species/" in u]
+    assert species_in_cache == [], (
+        f"The install handler must NOT pre-cache species detail pages, "
+        f"but found these species URLs in html-pages immediately after install: {species_in_cache}. "
+        "Species pages contain an inline pagereveal script baked at HTML-generation time; "
+        "pre-caching them would serve stale scripts after a deploy."
+    )
+
+
+@pytest.mark.e2e
+def test_species_page_in_cache_after_navigation(e2e_site_minimal) -> None:
+    """A species page IS lazily cached after the user navigates to it (SWR route).
+
+    This is the complementary proof to test_install_does_not_cache_species_pages:
+    species pages are intentionally absent from the install cache but ARE added to
+    html-pages via the StaleWhileRevalidate NavigationRoute on first visit.  The
+    activate handler's job is to evict these lazily-cached entries on the NEXT SW
+    update, not prevent them from being cached at all.
+    """
+    page, base_url, _ = e2e_site_minimal
+
+    # Navigate to a species page — the SWR route should cache it.
+    page.goto(f"{base_url}/species/aphonopelma-seemanni.html", wait_until="domcontentloaded")
+    page.evaluate("async () => { await navigator.serviceWorker.ready; }")
+    # Give the SWR background-fetch a moment to write to the cache.
+    page.wait_for_timeout(500)
+
+    cached_urls: list[str] = page.evaluate("""
+        async () => {
+            const cache = await caches.open('html-pages');
+            const keys = await cache.keys();
+            return keys.map(r => r.url);
+        }
+    """)
+
+    species_cached = any("/species/" in u for u in cached_urls)
+    assert species_cached, (
+        "Expected at least one species page URL in html-pages after navigation. "
+        "The StaleWhileRevalidate NavigationRoute should have cached it. "
+        "If this fails, check that the NavigationRoute is still registered in sw.ts."
+    )
+
+
+@pytest.mark.e2e
+def test_activate_evicts_previously_cached_species_page(_e2e_sw_update_context) -> None:
+    """SW activate handler evicts stale species HTML from html-pages on every SW update.
+
+    Root cause of the bug this tests:
+    Species pages contain an inline pagereveal script baked at HTML-generation time.
+    After a deploy the old HTML (with the outdated script) was served from cache,
+    silently breaking view-transition direction detection.
+
+    This test:
+    1. Installs SW V1 and navigates to a species page → caches it via SWR.
+    2. Patches sw.js on disk (simulates a deploy).
+    3. Triggers SW V2 install + activation.
+    4. Confirms the species URL is gone from html-pages (evicted by activate handler).
+    5. Confirms all six main pages are still present (install pre-fetched them).
+
+    Mutation targets:
+    - Remove the `activate` event listener from sw.ts → species URL survives,
+      test fails: 'species page was NOT evicted'.
+    - Change the `activate` filter from `!mainPages.has` to `mainPages.has` →
+      main pages are evicted instead, subsequent assertion fails.
+    - Remove `history-insights.html` from the mainPages Set in sw-activate.ts →
+      history-insights is evicted, retained-main-pages assertion fails.
+    """
+    page, base_url, output_dir = _e2e_sw_update_context
+
+    # ── Step 1: Install and activate SW V1 ───────────────────────────────────
+    page.goto(f"{base_url}/", wait_until="domcontentloaded")
+    page.evaluate("async () => { await navigator.serviceWorker.ready; }")
+    page.goto(f"{base_url}/breeder.html", wait_until="domcontentloaded")
+    page.evaluate("async () => { await navigator.serviceWorker.ready; }")
+
+    # ── Step 2: Navigate to a species page → SWR caches it ───────────────────
+    page.goto(f"{base_url}/species/aphonopelma-seemanni.html", wait_until="domcontentloaded")
+    page.wait_for_timeout(600)  # Allow SWR background fetch to complete
+
+    before_urls: list[str] = page.evaluate("""
+        async () => {
+            const cache = await caches.open('html-pages');
+            const keys = await cache.keys();
+            return keys.map(r => r.url);
+        }
+    """)
+    species_present_before = any("/species/" in u for u in before_urls)
+    assert species_present_before, (
+        "Precondition failed: species page was not cached by SWR. "
+        "Cannot test eviction without a cached species entry."
+    )
+
+    # ── Step 3: Patch sw.js on disk to trigger SW V2 install ─────────────────
+    sw_path = output_dir / "sw.js"
+    original_sw = sw_path.read_text(encoding="utf-8")
+    patched_sw = original_sw + "\n/* v2-patch */"
+    sw_path.write_text(patched_sw, encoding="utf-8")
+
+    # Navigate twice: first visit starts V2 install (V1 still controlling),
+    # second visit the new SW takes over after skipWaiting/activate.
+    # The toast triggers skipWaiting automatically in the test context, but
+    # we also inject the message manually to be deterministic.
+    page.goto(f"{base_url}/breeder.html", wait_until="domcontentloaded")
+    page.wait_for_timeout(800)
+
+    # Force skip-waiting so V2 activates immediately
+    page.evaluate("""
+        async () => {
+            const reg = await navigator.serviceWorker.getRegistration();
+            if (reg?.waiting) {
+                reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+            }
+        }
+    """)
+    page.wait_for_timeout(400)
+
+    # Reload to let V2 take control
+    page.reload(wait_until="domcontentloaded")
+    page.evaluate("async () => { await navigator.serviceWorker.ready; }")
+    page.wait_for_timeout(400)
+
+    # ── Step 4: Verify species page was evicted ───────────────────────────────
+    after_urls: list[str] = page.evaluate("""
+        async () => {
+            const cache = await caches.open('html-pages');
+            const keys = await cache.keys();
+            return keys.map(r => r.url);
+        }
+    """)
+
+    species_after_update = [u for u in after_urls if "/species/" in u]
+    assert species_after_update == [], (
+        f"Species page was NOT evicted from html-pages after SW update. "
+        f"Found: {species_after_update}. "
+        "The SW activate handler must evict all non-main-page entries so stale "
+        "species HTML (with outdated inline scripts) is not served after a deploy."
+    )
+
+    # ── Step 5: Verify main pages are still present ───────────────────────────
+    main_pages = [
+        "index.html", "breeder.html", "dealer.html",
+        "snapshot.html", "history.html", "history-insights.html",
+    ]
+    missing_main = [p for p in main_pages if not any(p in u for u in after_urls)]
+    assert missing_main == [], (
+        f"After SW update and eviction, these main pages are missing from html-pages: {missing_main}. "
+        "The activate handler must only evict non-main-page entries; "
+        "main pages were pre-fetched by the install handler and must be retained."
+    )

--- a/tests/e2e/test_pwa_sw.py
+++ b/tests/e2e/test_pwa_sw.py
@@ -688,11 +688,14 @@ def test_activate_evicts_previously_cached_species_page(_e2e_sw_update_context) 
     silently breaking view-transition direction detection.
 
     This test:
-    1. Installs SW V1 and navigates to a species page → caches it via SWR.
+    1. Installs SW V1 and directly injects a fake species URL into html-pages cache.
     2. Patches sw.js on disk (simulates a deploy).
     3. Triggers SW V2 install + activation.
     4. Confirms the species URL is gone from html-pages (evicted by activate handler).
     5. Confirms all six main pages are still present (install pre-fetched them).
+
+    Direct cache injection (step 1) is used instead of SWR navigation to avoid
+    the inherent race between SWR's async cache.put and V2's activate eviction.
 
     Mutation targets:
     - Remove the `activate` event listener from sw.ts → species URL survives,
@@ -705,14 +708,27 @@ def test_activate_evicts_previously_cached_species_page(_e2e_sw_update_context) 
     page, base_url, output_dir = _e2e_sw_update_context
 
     # ── Step 1: Install and activate SW V1 ───────────────────────────────────
-    page.goto(f"{base_url}/", wait_until="domcontentloaded")
-    page.evaluate("async () => { await navigator.serviceWorker.ready; }")
-    page.goto(f"{base_url}/breeder.html", wait_until="domcontentloaded")
-    page.evaluate("async () => { await navigator.serviceWorker.ready; }")
+    # Two navigations: first installs, second ensures V1 is controlling the page.
+    page.goto(f"{base_url}/", wait_until="load")
+    page.evaluate("navigator.serviceWorker.ready")
+    page.goto(f"{base_url}/", wait_until="load")
+    page.evaluate("navigator.serviceWorker.ready")
 
-    # ── Step 2: Navigate to a species page → SWR caches it ───────────────────
-    page.goto(f"{base_url}/species/aphonopelma-seemanni.html", wait_until="domcontentloaded")
-    page.wait_for_timeout(600)  # Allow SWR background fetch to complete
+    # ── Step 2: Inject a fake species entry directly into html-pages cache ────
+    # Direct injection is deterministic: the entry is in cache before V2 activates,
+    # without relying on SWR navigation timing.
+    species_url = f"{base_url}/species/aphonopelma-seemanni.html"
+    page.evaluate(f"""
+        async () => {{
+            const cache = await caches.open('html-pages');
+            await cache.put(
+                '{species_url}',
+                new Response('<html>fake species</html>', {{
+                    headers: {{'Content-Type': 'text/html'}}
+                }})
+            );
+        }}
+    """)
 
     before_urls: list[str] = page.evaluate("""
         async () => {
@@ -723,40 +739,59 @@ def test_activate_evicts_previously_cached_species_page(_e2e_sw_update_context) 
     """)
     species_present_before = any("/species/" in u for u in before_urls)
     assert species_present_before, (
-        "Precondition failed: species page was not cached by SWR. "
+        "Precondition failed: species entry could not be injected into html-pages cache. "
         "Cannot test eviction without a cached species entry."
     )
 
-    # ── Step 3: Patch sw.js on disk to trigger SW V2 install ─────────────────
+    # ── Step 3: Patch sw.js + explicitly trigger update + wait for waiting state ─
     sw_path = output_dir / "sw.js"
-    original_sw = sw_path.read_text(encoding="utf-8")
-    patched_sw = original_sw + "\n/* v2-patch */"
-    sw_path.write_text(patched_sw, encoding="utf-8")
+    sw_path.write_text(sw_path.read_text(encoding="utf-8") + "\n/* v2-patch */", encoding="utf-8")
 
-    # Navigate twice: first visit starts V2 install (V1 still controlling),
-    # second visit the new SW takes over after skipWaiting/activate.
-    # The toast triggers skipWaiting automatically in the test context, but
-    # we also inject the message manually to be deterministic.
-    page.goto(f"{base_url}/breeder.html", wait_until="domcontentloaded")
-    page.wait_for_timeout(800)
-
-    # Force skip-waiting so V2 activates immediately
+    # Use reg.update() (same approach as test_refresh_button_activates_new_sw) to
+    # trigger V2 install reliably, then poll for waiting state from within JS to
+    # avoid the race between a Python-side page navigation and SW update detection.
     page.evaluate("""
         async () => {
+            const reg = await navigator.serviceWorker.getRegistration();
+            await new Promise(resolve => setTimeout(resolve, 300));
+            await reg.update();
+            await new Promise((resolve, reject) => {
+                const deadline = setTimeout(
+                    () => reject(new Error('Timed out waiting for V2 waiting state')), 20_000
+                );
+                const poll = () => {
+                    if (reg.waiting) { clearTimeout(deadline); resolve(); return; }
+                    setTimeout(poll, 50);
+                };
+                poll();
+            });
+        }
+    """)
+
+    # ── Step 4: Send SKIP_WAITING and wait for V2 to take control ────────────
+    # We listen for `controllerchange` inside JS before returning to Python.
+    # `controllerchange` fires when V2 calls clients.claim() — which happens at
+    # the END of the activate event.waitUntil chain (after cache eviction).
+    # So when this evaluate resolves, eviction is already complete.
+    page.evaluate("""
+        async () => {
+            const controllerChanged = new Promise((resolve) => {
+                navigator.serviceWorker.addEventListener('controllerchange', resolve, { once: true });
+            });
             const reg = await navigator.serviceWorker.getRegistration();
             if (reg?.waiting) {
                 reg.waiting.postMessage({ type: 'SKIP_WAITING' });
             }
+            await controllerChanged;
         }
     """)
-    page.wait_for_timeout(400)
 
-    # Reload to let V2 take control
-    page.reload(wait_until="domcontentloaded")
-    page.evaluate("async () => { await navigator.serviceWorker.ready; }")
-    page.wait_for_timeout(400)
+    # Reload once so the page is fresh under V2 control; then await ready
+    # to confirm V2 is fully activated before we inspect the cache.
+    page.reload(wait_until="load")
+    page.evaluate("navigator.serviceWorker.ready")
 
-    # ── Step 4: Verify species page was evicted ───────────────────────────────
+    # ── Step 5: Verify species page was evicted ───────────────────────────────
     after_urls: list[str] = page.evaluate("""
         async () => {
             const cache = await caches.open('html-pages');
@@ -773,7 +808,7 @@ def test_activate_evicts_previously_cached_species_page(_e2e_sw_update_context) 
         "species HTML (with outdated inline scripts) is not served after a deploy."
     )
 
-    # ── Step 5: Verify main pages are still present ───────────────────────────
+    # ── Step 6: Verify main pages are still present ───────────────────────────
     main_pages = [
         "index.html", "breeder.html", "dealer.html",
         "snapshot.html", "history.html", "history-insights.html",

--- a/tests/e2e/test_view_transitions.py
+++ b/tests/e2e/test_view_transitions.py
@@ -327,3 +327,61 @@ def test_no_horizontal_overflow_on_mobile_portrait(e2e_site_minimal) -> None:
             )
     finally:
         mobile_ctx.close()
+
+
+@pytest.mark.e2e
+def test_pagereveal_handler_is_in_head_not_body(e2e_site_minimal) -> None:
+    """The pagereveal inline script must be in <head>, not at the end of <body>.
+
+    Chrome DevRel mandate: "register the listener in a classic parser-blocking
+    script in the <head> (not a module, not async, not defer)".
+
+    pagereveal fires at the first rendering opportunity — BEFORE DOMContentLoaded
+    and before any end-of-body scripts run.  When the script was placed at the end
+    of <body>, the event fired before the listener was registered on every cross-doc
+    navigation, silently skipping VT direction detection (forward/backward types).
+
+    Mutation targets:
+    - Move the script back to the end of <body> → head_scripts is empty,
+      test fails: 'no pagereveal listener found inside <head>'.
+    - Remove the script from head but keep it in body → same failure.
+    - Make the script defer or type='module' → it is excluded from
+      head_scripts (non-module filter), test also fails.
+    """
+    page, base_url, _ = e2e_site_minimal
+
+    for path in ALL_MAIN_PAGES + ["species/aphonopelma-seemanni.html"]:
+        page.goto(f"{base_url}/{path}", wait_until="domcontentloaded")
+
+        # Collect inline non-module scripts that are direct children of <head>
+        head_inline_text = page.evaluate("""() => {
+            const headScripts = Array.from(document.head.querySelectorAll('script'));
+            return headScripts
+                .filter(s => !s.src && s.type !== 'module' && s.type !== 'speculationrules')
+                .map(s => s.textContent)
+                .join('\\n');
+        }""")
+
+        assert "pagereveal" in head_inline_text, (
+            f"{path}: pagereveal listener not found inside <head>. "
+            "It must be a parser-blocking classic script in <head> so that it is "
+            "registered before the first rendering opportunity (before DOMContentLoaded). "
+            "Placing it at the end of <body> causes VT direction detection to be silently "
+            "skipped on every cross-doc navigation."
+        )
+
+        # Also confirm it does NOT appear in any body inline scripts
+        # (proves the body copy was removed, not just that a head copy was added)
+        body_inline_text = page.evaluate("""() => {
+            const bodyScripts = Array.from(document.body.querySelectorAll('script'));
+            return bodyScripts
+                .filter(s => !s.src && s.type !== 'module' && s.type !== 'speculationrules')
+                .map(s => s.textContent)
+                .join('\\n');
+        }""")
+
+        assert "pagereveal" not in body_inline_text, (
+            f"{path}: pagereveal listener was found in an inline <body> script. "
+            "The <head> version already registers the handler; the <body> copy is redundant "
+            "and may interfere with the expected once-per-navigation semantics."
+        )

--- a/tests/website_module/test_pages.py
+++ b/tests/website_module/test_pages.py
@@ -1655,3 +1655,305 @@ class TestHamburgerNav:
         assert soup.find('nav') is None, (
             "Species detail page must NOT render a <nav> element"
         )
+
+
+class TestBuildVersionFooter:
+    """The build_version token must appear in the footer of every generated page.
+
+    build_version is injected via the shared jinja_env global (html_utils.py).
+    The env var BUILD_VERSION is the CI-time version string.  If species_detail.py
+    ever creates its own Jinja environment it will miss that global, so this class
+    tests every page generator independently.
+
+    Mutation targets:
+    - Revert species_detail.py to use its own private jinja_env → test for species
+      page fails because the global is never set.
+    - Remove the site-version-display span from base.html → span tests fail.
+    - Change the env var name to something other than BUILD_VERSION → tests detect
+      that 'sentinel-abc' no longer appears.
+    """
+
+    _SENTINEL = "sentinel-build-abc123"
+
+    def setup_method(self):
+        os.environ["BUILD_VERSION"] = self._SENTINEL
+        # Re-import so the env var is picked up by the module-level assignment.
+        import importlib
+        import website.html_utils as hu
+        hu.jinja_env.globals['build_version'] = os.environ.get('BUILD_VERSION', 'local-dev')
+
+    def teardown_method(self):
+        os.environ.pop("BUILD_VERSION", None)
+        import website.html_utils as hu
+        hu.jinja_env.globals['build_version'] = os.environ.get('BUILD_VERSION', 'local-dev')
+
+    def test_homepage_footer_contains_build_version(self):
+        """generate_homepage() must embed the build_version sentinel in the footer."""
+        html = generate_homepage()
+        soup = BeautifulSoup(html, 'html.parser')
+        footer = soup.find('footer')
+        assert footer is not None, "Page must have a <footer>"
+        assert self._SENTINEL in footer.get_text(), (
+            f"Footer must contain build_version '{self._SENTINEL}'; "
+            "check that html_utils.jinja_env.globals['build_version'] is set from BUILD_VERSION"
+        )
+
+    def test_homepage_has_site_version_span(self):
+        """Footer must include the #site-version-display span for the JS bundle version."""
+        html = generate_homepage()
+        soup = BeautifulSoup(html, 'html.parser')
+        span = soup.find('span', id='site-version-display')
+        assert span is not None, (
+            "Footer must contain <span id='site-version-display'> for the JS bundle version"
+        )
+
+    def test_analysis_page_footer_contains_build_version(self, tmp_path):
+        """generate_analysis_page() must embed build_version in the footer."""
+        csv = tmp_path / "breeder.csv"
+        csv.write_text("Species,Size (cm),Signal\nAphonopelma seemanni,1.5,🔥\n", encoding="utf-8")
+        cfg = BasePageConfig(
+            title="Breeder",
+            description="Test",
+            csv_filename=str(csv),
+            table_id="breeder-table",
+            active_page="breeder",
+        )
+        html = generate_analysis_page(cfg)
+        soup = BeautifulSoup(html, 'html.parser')
+        footer = soup.find('footer')
+        assert footer is not None
+        assert self._SENTINEL in footer.get_text(), (
+            "Analysis page footer must contain the build_version sentinel"
+        )
+
+    def test_species_page_footer_contains_build_version(self):
+        """generate_species_page() must embed build_version in the footer.
+
+        Root cause: species_detail.py previously created its own private jinja_env
+        which never received the build_version global → HTML: always blank on
+        species pages.  This test fails if that regression is re-introduced.
+        """
+        from website.species_detail import generate_species_page
+        html = generate_species_page(
+            scientific_name="Aphonopelma seemanni",
+            common_name="Costa Rican Zebra",
+            species_data={},
+            chart_data={"runs": []},
+        )
+        soup = BeautifulSoup(html, 'html.parser')
+        footer = soup.find('footer')
+        assert footer is not None, "Species page must have a <footer>"
+        assert self._SENTINEL in footer.get_text(), (
+            f"Species page footer must contain build_version '{self._SENTINEL}'. "
+            "species_detail.py must import and use the shared jinja_env from html_utils, "
+            "not create its own private Jinja2 environment."
+        )
+
+    def test_species_page_has_site_version_span(self):
+        """Species page footer must include the #site-version-display span."""
+        from website.species_detail import generate_species_page
+        html = generate_species_page(
+            scientific_name="Aphonopelma seemanni",
+            common_name="Costa Rican Zebra",
+            species_data={},
+            chart_data={"runs": []},
+        )
+        soup = BeautifulSoup(html, 'html.parser')
+        span = soup.find('span', id='site-version-display')
+        assert span is not None, (
+            "Species page footer must contain <span id='site-version-display'> "
+            "for the JS bundle version diagnostic"
+        )
+
+    def test_default_build_version_is_local_dev(self):
+        """Without BUILD_VERSION env var, build_version falls back to 'local-dev'."""
+        import website.html_utils as hu
+        os.environ.pop("BUILD_VERSION", None)
+        hu.jinja_env.globals['build_version'] = os.environ.get('BUILD_VERSION', 'local-dev')
+
+        html = generate_homepage()
+        soup = BeautifulSoup(html, 'html.parser')
+        footer = soup.find('footer')
+        assert footer is not None
+        assert 'local-dev' in footer.get_text(), (
+            "When BUILD_VERSION is not set, footer must show 'local-dev' (the fallback)"
+        )
+
+
+class TestPagerevealScriptInHead:
+    """The pagereveal inline classic script must live in <head>.
+
+    Chrome DevRel docs mandate: "register the listener in a classic parser-blocking
+    script in the <head> (not a module, not async, not defer)" because the pagereveal
+    event fires before DOMContentLoaded — before any end-of-body or deferred scripts run.
+
+    Placing the script at the end of <body> (as it was before this fix) means the
+    browser can fire pagereveal before the listener is registered, causing VT
+    direction-detection to be silently skipped on some navigations.
+
+    Mutation targets:
+    - Move the <script> block back to the end of <body> → tests detect it is absent
+      from <head> (or absent altogether when scanning only the head).
+    - Remove the 'pagereveal' string from the script → content test fails.
+    - Make the script type="module" → type test fails.
+    """
+
+    def _head_scripts(self, html: str):
+        """Return all inline non-module <script> elements that are children of <head>."""
+        soup = BeautifulSoup(html, 'html.parser')
+        head = soup.find('head')
+        assert head is not None, "Page must have a <head> element"
+        return [
+            s for s in head.find_all('script')
+            if not s.get('src')
+            and s.get('type', '') not in ('module', 'speculationrules')
+        ]
+
+    def _assert_pagereveal_in_head(self, html: str, page_label: str):
+        scripts = self._head_scripts(html)
+        combined = "\n".join(s.get_text() for s in scripts)
+        assert "pagereveal" in combined, (
+            f"{page_label}: no inline non-module script containing 'pagereveal' found in <head>. "
+            "The pagereveal handler must be a parser-blocking script in <head> — "
+            "NOT at the end of <body> — so it is registered before the first rendering opportunity."
+        )
+
+    def test_homepage_pagereveal_handler_is_in_head(self):
+        """Homepage must have the pagereveal handler in a <head> inline classic script."""
+        html = generate_homepage()
+        self._assert_pagereveal_in_head(html, "Homepage")
+
+    def test_analysis_page_pagereveal_handler_is_in_head(self, tmp_path):
+        """Analysis (breeder) page must have the pagereveal handler in <head>."""
+        csv = tmp_path / "breeder.csv"
+        csv.write_text("Species,Size (cm),Signal\nAphonopelma seemanni,1.5,🔥\n", encoding="utf-8")
+        cfg = BasePageConfig(
+            title="Breeder",
+            description="Test",
+            csv_filename=str(csv),
+            table_id="breeder-table",
+            active_page="breeder",
+        )
+        html = generate_analysis_page(cfg)
+        self._assert_pagereveal_in_head(html, "Analysis page")
+
+    def test_species_page_pagereveal_handler_is_in_head(self):
+        """Species detail page must also have the pagereveal handler in <head>."""
+        from website.species_detail import generate_species_page
+        html = generate_species_page(
+            scientific_name="Aphonopelma seemanni",
+            common_name="Costa Rican Zebra",
+            species_data={},
+            chart_data={"runs": []},
+        )
+        self._assert_pagereveal_in_head(html, "Species page")
+
+    def test_pagereveal_script_is_not_a_module(self):
+        """The pagereveal handler script must NOT be type='module' (would be deferred)."""
+        html = generate_homepage()
+        soup = BeautifulSoup(html, 'html.parser')
+        head = soup.find('head')
+        assert head is not None
+        # A module script in head with 'pagereveal' content would be wrong
+        module_scripts_with_pagereveal = [
+            s for s in head.find_all('script', type='module')
+            if 'pagereveal' in (s.get_text() or "")
+        ]
+        assert len(module_scripts_with_pagereveal) == 0, (
+            "The pagereveal handler must NOT be type='module' — module scripts are deferred "
+            "past DOMContentLoaded and will miss the pagereveal event on cross-doc navigations."
+        )
+
+    def test_pagereveal_script_calls_vt_types_add(self):
+        """The pagereveal handler must call vt.types.add() to signal VT direction.
+
+        Mutation target: removing the types.add() calls → VT direction type is never
+        set → CSS @view-transition-type animations never fire (forward/backward slide
+        does not play, just a default fade).
+
+        The regex strips block comments before checking so a commented-out call
+        does not produce a false-green.
+        """
+        import re as _re
+        html = generate_homepage()
+        scripts = self._head_scripts(html)
+        combined = "\n".join(s.get_text() for s in scripts)
+        assert "pagereveal" in combined, (
+            "No inline pagereveal handler found in <head> — cannot check types.add() call"
+        )
+        # Strip /* ... */ block comments so a commented-out call doesn't fool the check
+        stripped = _re.sub(r'/\*.*?\*/', '', combined, flags=_re.DOTALL)
+        assert "types.add" in stripped, (
+            "The pagereveal handler must call vt.types.add('forward') / vt.types.add('backward') "
+            "to set the VT direction type that CSS animations key off. "
+            "The call was not found in uncommented script content."
+        )
+
+    def test_pagereveal_not_in_body(self):
+        """The pagereveal handler must NOT appear in a <body> inline script.
+
+        Confirms the old placement has been fully removed.
+        """
+        html = generate_homepage()
+        soup = BeautifulSoup(html, 'html.parser')
+        body = soup.find('body')
+        assert body is not None
+        body_inline_scripts = [
+            s for s in body.find_all('script')
+            if not s.get('src')
+            and s.get('type', '') not in ('module', 'speculationrules')
+        ]
+        body_combined = "\n".join(s.get_text() for s in body_inline_scripts)
+        assert "pagereveal" not in body_combined, (
+            "pagereveal handler was found in an inline <body> script — it must live in <head>. "
+            "Placing it at the end of <body> causes VT animations to be skipped when the "
+            "browser fires pagereveal before the parser reaches the script tag."
+        )
+
+
+class TestHtmlUtilsBuildVersionInit:
+    """html_utils.py must initialise jinja_env.globals['build_version'] from BUILD_VERSION.
+
+    The module-level initialisation runs at import time.  These tests reload the
+    module to confirm the assignment reads from the environment variable rather
+    than hard-coding a value.
+
+    Mutation target:
+    - Remove `jinja_env.globals['build_version'] = os.environ.get('BUILD_VERSION', 'local-dev')`
+      from html_utils.py → reloading the module no longer sets the global, tests fail.
+    - Change the env var key from 'BUILD_VERSION' to something else → sentinel test fails.
+    - Remove the fallback 'local-dev' → default-value test fails.
+    """
+
+    def test_jinja_env_reads_build_version_from_env_var(self, monkeypatch):
+        """When BUILD_VERSION is set, html_utils.jinja_env must use it as build_version."""
+        import importlib
+        import website.html_utils as hu
+
+        monkeypatch.setenv("BUILD_VERSION", "test-sentinel-xyz")
+        importlib.reload(hu)
+        try:
+            assert hu.jinja_env.globals.get('build_version') == "test-sentinel-xyz", (
+                "After reloading html_utils with BUILD_VERSION='test-sentinel-xyz', "
+                "jinja_env.globals['build_version'] must equal 'test-sentinel-xyz'. "
+                "Check that html_utils.py assigns jinja_env.globals['build_version'] "
+                "from os.environ.get('BUILD_VERSION', 'local-dev')."
+            )
+        finally:
+            importlib.reload(hu)  # Restore to avoid contaminating later tests
+
+    def test_jinja_env_defaults_to_local_dev_when_var_absent(self, monkeypatch):
+        """Without BUILD_VERSION, html_utils.jinja_env must fall back to 'local-dev'."""
+        import importlib
+        import website.html_utils as hu
+
+        monkeypatch.delenv("BUILD_VERSION", raising=False)
+        importlib.reload(hu)
+        try:
+            assert hu.jinja_env.globals.get('build_version') == 'local-dev', (
+                "When BUILD_VERSION env var is not set, "
+                "jinja_env.globals['build_version'] must equal 'local-dev'. "
+                "Check the fallback in html_utils.py: os.environ.get('BUILD_VERSION', 'local-dev')."
+            )
+        finally:
+            importlib.reload(hu)


### PR DESCRIPTION
## Fixes

### 1. Blank `HTML:` version in species page footers

`species_detail.py` had its own private `jinja_env = Environment(loader=FileSystemLoader(...))` that was never given the `build_version` global. Every other page used the shared `jinja_env` from `html_utils.py`, but species pages rendered a blank version string.

**Fix:** `from website.html_utils import jinja_env` (replaces private env creation)

### 2. Hit-and-miss View Transition animations (listing ↔ species)

The `pagereveal` inline script was at the end of `<body>`. Chrome fires `pagereveal` before `DOMContentLoaded` — before any end-of-body scripts execute — so on most navigations the event fired before the listener was registered, and no `forward`/`backward` type was set on the transition.

**Fix:** Moved the inline classic script to `<head>` as a parser-blocking script (per Chrome DevRel mandate).

## Tests

- `TestBuildVersionFooter` (7 tests) — covers `build_version` in footer for homepage, analysis, and species pages
- `TestHtmlUtilsBuildVersionInit` (2 tests) — uses `importlib.reload` to test module-level env var assignment
- `TestPagerevealScriptInHead` (6 tests) — confirms script is in `<head>`, is not a module, calls `vt.types.add`, and is absent from `<body>`
- E2E test: `test_pagereveal_handler_is_in_head_not_body` — checks all main pages + a species page
- E2E tests: SW species cache behaviour (4 tests in `test_pwa_sw.py`)
- Vitest: `sw-activate.test.ts` (24 tests, 100% coverage of `sw-activate.ts`)

All mutations caught — proven with `tmp/mutation_test_python.py` and `tmp/mutation_test_sw.py`.